### PR TITLE
remove the "is" warning for python 3.8

### DIFF
--- a/pydfnworks/pydfnworks/dfnFlow/pflotran.py
+++ b/pydfnworks/pydfnworks/dfnFlow/pflotran.py
@@ -154,7 +154,7 @@ def zone2ex(self, uge_file='', zone_file='', face='',
     print('--> Finished with uge file\n')
 
     # loop through zone files
-    if zone_file is 'all':
+    if zone_file == 'all':
         zone_files = ['pboundary_front_n.zone', 'pboundary_back_s.zone', 'pboundary_left_w.zone', \
                         'pboundary_right_e.zone', 'pboundary_top.zone', 'pboundary_bottom.zone']
         face_names = ['north', 'south', 'west', 'east', 'top', 'bottom']

--- a/pydfnworks/pydfnworks/dfnGen/distributions.py
+++ b/pydfnworks/pydfnworks/dfnGen/distributions.py
@@ -37,8 +37,8 @@ class distr():
             prefix : str
                 Indicates shapes that the beta distribution describes. 'e' if they are ellipses, 'r' if they are rectangles.
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        numFamilies = self.ellipseFams if prefix is 'e' else self.rectFams
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        numFamilies = self.ellipseFams if prefix == 'e' else self.rectFams
         paramName = prefix + "betaDistribution"
 
         errResult = distr_helper_methods.verify_list(
@@ -71,9 +71,9 @@ class distr():
         each distribution is either 1 (log-normal), 2 (Truncated Power Law), 3 (Exponential), or 4 (constant).
         Stores how many of each distrib are in use in numEdistribs or numRdistribs lists.  
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        distribList = self.numEdistribs if prefix is 'e' else self.numRdistribs
-        numFamilies = self.ellipseFams if prefix is 'e' else self.rectFams
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        distribList = self.numEdistribs if prefix == 'e' else self.numRdistribs
+        numFamilies = self.ellipseFams if prefix == 'e' else self.rectFams
         paramName = prefix + "distr"
 
         errResult = distr_helper_methods.verify_list(
@@ -98,8 +98,8 @@ class distr():
         """
         Verifies all logNormal Parameters for ellipses and Rectangles.
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        distribList = self.numEdistribs if prefix is 'e' else self.numRdistribs
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        distribList = self.numEdistribs if prefix == 'e' else self.numRdistribs
         paramNames = [
             prefix + name for name in ["LogMean", "sd", "LogMin", "LogMax"]
         ]
@@ -138,8 +138,8 @@ class distr():
         """
         Verifies parameters for truncated power law distribution of fractures.
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        distribList = self.numEdistribs if prefix is 'e' else self.numRdistribs
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        distribList = self.numEdistribs if prefix == 'e' else self.numRdistribs
         paramNames = [prefix + name for name in ["min", "max", "alpha"]]
         errString = "\"{}\" has defined {} value(s) but {} truncated power-law distrbution(s) was(were) " \
                 "defined in \"{}\". Please define one value for each truncated power-law (distrib. #2) family."
@@ -166,8 +166,8 @@ class distr():
         """
         Verifies parameters for exponential distribution of fractures.
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        distribList = self.numEdistribs if prefix is 'e' else self.numRdistribs
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        distribList = self.numEdistribs if prefix == 'e' else self.numRdistribs
         paramNames = [
             prefix + name for name in ["ExpMean", "ExpMin", "ExpMax"]
         ]
@@ -199,8 +199,8 @@ class distr():
         Verifies parameters for constant distribution of fractures
         """
         paramName = prefix + "const"
-        numFamilies = self.ellipseFams if prefix is 'e' else self.rectFams
-        distribList = self.numEdistribs if prefix is 'e' else self.numRdistribs
+        numFamilies = self.ellipseFams if prefix == 'e' else self.rectFams
+        distribList = self.numEdistribs if prefix == 'e' else self.numRdistribs
 
         errResult = distr_helper_methods.verify_list(
             distr_helper_methods.value_of(paramName),

--- a/pydfnworks/pydfnworks/dfnGen/gen_input.py
+++ b/pydfnworks/pydfnworks/dfnGen/gen_input.py
@@ -275,7 +275,7 @@ class input_helper():
     def verify_flag(self, value, key="", inList=False):
         """ Verify that value is either a 0 or a 1.
         """
-        if value is '0' or value is '1':
+        if value == '0' or value == '1':
             return int(value)
         elif inList:
             return None
@@ -984,7 +984,7 @@ def check_input(self, input_file='', output_file=''):
     def compare_pts_v_sh(prefix, hval):
         """ Check that the rectangles and ellipses generated will not involve features with length less than 3*h value used in FRAM. 
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
+        shape = "ellipse" if prefix == 'e' else "rectangle"
         aspectList = params[prefix + "aspect"][0]
         numPointsList = None
 
@@ -1099,8 +1099,8 @@ def check_input(self, input_file='', output_file=''):
 
     def aspect(prefix):
         """ Check the aspect of the the rectangle or ellipse families. """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        numFamilies = ellipseFams if prefix is 'e' else rectFams
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        numFamilies = ellipseFams if prefix == 'e' else rectFams
         paramName = prefix + "aspect"
 
         errResult = input_helper_methods.verify_list(
@@ -1122,8 +1122,8 @@ def check_input(self, input_file='', output_file=''):
 
     def layer(prefix):
         """ Check the number of layers. """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        numFamilies = ellipseFams if prefix is 'e' else rectFams
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        numFamilies = ellipseFams if prefix == 'e' else rectFams
         paramName = prefix + "Layer"
 
         errResult = input_helper_methods.verify_list(
@@ -1150,8 +1150,8 @@ def check_input(self, input_file='', output_file=''):
     def theta_phi_kappa(prefix):
         """ Check the angle parameters used for Fisher distributions 
         """
-        shape = "ellipse" if prefix is 'e' else "rectangle"
-        numFamilies = ellipseFams if prefix is 'e' else rectFams
+        shape = "ellipse" if prefix == 'e' else "rectangle"
+        numFamilies = ellipseFams if prefix == 'e' else rectFams
         paramNames = [prefix + name for name in ["theta", "phi", "kappa"]]
         errString = "\"{}\" has defined {} angle(s) but there is(are) {} {} family(ies)."\
                 "Please defined one angle for each {} family."

--- a/pydfnworks/pydfnworks/dfnGraph/dfn2graph.py
+++ b/pydfnworks/pydfnworks/dfnGraph/dfn2graph.py
@@ -204,7 +204,7 @@ def create_intersection_graph(inflow,
     for i in range(len(frac_edges)):
         f1 = int(frac_edges[i][0])
         keep = True
-        if frac_edges[i][1] is 's' or frac_edges[i][1] is 't':
+        if frac_edges[i][1] == 's' or frac_edges[i][1] == 't':
             f2 = frac_edges[i][1]
         elif int(frac_edges[i][1]) > 0:
             f2 = int(frac_edges[i][1])

--- a/pydfnworks/pydfnworks/general/dfnworks.py
+++ b/pydfnworks/pydfnworks/general/dfnworks.py
@@ -218,7 +218,7 @@ def commandline_options():
                         type=str,
                         help="Path to original DFN files")
     options = parser.parse_args()
-    if options.jobname is "":
+    if options.jobname == "":
         error = "Error: Jobname is required. Exiting.\n"
         sys.stderr.write(error)
         sys.exit(1)

--- a/pydfnworks/pydfnworks/general/general_functions.py
+++ b/pydfnworks/pydfnworks/general/general_functions.py
@@ -57,7 +57,7 @@ def print_run_time(self):
     f = open(run_time_file).readlines()
     unit = f[-1].split()[-1]
     total = float(f[-1].split()[-2])
-    if unit is 'minutes':
+    if unit == 'minutes':
         total *= 60.0
 
     print('Runs times for ', f[0])
@@ -67,7 +67,7 @@ def print_run_time(self):
         unit = f[i].split()[-1]
         time = float(f[i].split()[-2])
 
-        if unit is 'minutes':
+        if unit == 'minutes':
             time *= 60.0
         percent.append(100.0 * (time / total))
         name.append(f[i].split(':')[1])

--- a/pydfnworks/pydfnworks/general/paths.py
+++ b/pydfnworks/pydfnworks/general/paths.py
@@ -1,4 +1,4 @@
-rom shutil import move
+from shutil import move
 import os
 import sys
 import subprocess


### PR DESCRIPTION
1. there is a bug in pydfnworks/general/paths.py, "rom" should be "from".
2. replace "is" with "==" for the string comaring. 
