### PR TITLE
Fix a couple of build/install issues

### DIFF
--- a/DFNTrans/TrackingPart.c
+++ b/DFNTrans/TrackingPart.c
@@ -27,7 +27,7 @@ struct lagrangian { /*! data structure of Lagrangian variables */
 
 struct lagrangian lagvariable;
 unsigned int FLAG_OUT = 0, all_out = 0;
-unsigned int np, t, nodeID = 0, avs_o = 0, traj_o = 0, curv_o = 0, no_out = 0, tdrw = 0, mixing_rule = 1;
+unsigned int t, nodeID = 0, avs_o = 0, traj_o = 0, curv_o = 0, no_out = 0, tdrw = 0, mixing_rule = 1;
 unsigned int marfa = 0, plumec = 0, disp_o = 0, timecounter = 0, frac_o = 0, tfile = 0, tdrw_o = 0, tdrw_limited = 0;
 double tdrw_porosity = 0.0, tdrw_diffcoeff = 0.0, t_adv0 = 0.0, t_adv = 0.0, timediff = 0.0; //, tdrw_lambda = 0.0;
 struct intcoef { /*! Interpolation coefficients: barycentric interpolation is used to define instantaneous particle's velocity from Darcy velocities defined on triangular cell vertices.*/

--- a/pydfnworks/pydfnworks/dfnFlow/pflotran.py
+++ b/pydfnworks/pydfnworks/dfnFlow/pflotran.py
@@ -466,7 +466,13 @@ def pflotran(self, transient=False, restart=False, restart_file=''):
 
     print("=" * 80)
     print("--> Running PFLOTRAN")
-    cmd = os.environ['PETSC_DIR']+'/'+os.environ['PETSC_ARCH']+'/bin/mpirun -np ' + str(self.ncpu) + \
+
+    mpirun = os.environ['PETSC_DIR']+'/'+os.environ['PETSC_ARCH']+'/bin/mpirun'
+    if not (os.path.isfile(mpirun) and os.access(mpirun, os.X_OK)):
+        # PETSc did not install MPI. Hopefully, the user has their own MPI.
+        mpirun = 'mpirun'
+
+    cmd = mpirun + ' -np ' + str(self.ncpu) + \
           ' ' + os.environ['PFLOTRAN_EXE'] + ' -pflotranin ' + self.local_dfnFlow_file
     print("Running: %s" % cmd)
     subprocess.call(cmd, shell=True)

--- a/pydfnworks/pydfnworks/general/paths.py
+++ b/pydfnworks/pydfnworks/general/paths.py
@@ -101,6 +101,11 @@ def define_paths():
             'FEHM_EXE': ''
         }
 
+    # Or, read the variables from the environment
+    for envVar in env_paths:
+        if env_paths[envVar] == '':
+            env_paths[envVar] = os.environ.get(envVar, '')
+
     # the dfnworks-main  repository
     os.environ['dfnworks_PATH'] = env_paths['dfnworks_PATH']
     valid("dfnworks_PATH", os.environ['dfnworks_PATH'], "directory")


### PR DESCRIPTION
- Fix compile issue in DFNTrans for gcc > 8.
- Handle case where PETSc did not install its own MPI.
- Allow to read dfnWorks paths and executables from env variables.