### PR TITLE
Disabled checking that the lognnormal mu > 0

### DIFF
--- a/pydfnworks/pydfnworks/dfnGen/generation/input_checking/parameter_checking_general.py
+++ b/pydfnworks/pydfnworks/dfnGen/generation/input_checking/parameter_checking_general.py
@@ -297,7 +297,6 @@ def check_aperture(params):
 
     if params['aperture']['value'] == 1:
         hf.check_none('meanAperture', params['meanAperture']['value'])
-        hf.check_values('meanAperture', params['meanAperture']['value'], 0)
         hf.check_none('stdAperture', params['stdAperture']['value'])
         hf.check_values('stdAperture', params['stdAperture']['value'], 0)
 


### PR DESCRIPTION
Disabled checking that the mu in the underlying normal distribution for apertures is positive. It is not required to be positive; that would force aperture values to be above 1.