### PR TITLE
Bug fix for #95

### DIFF
--- a/pydfnworks/pydfnworks/general/dfnworks.py
+++ b/pydfnworks/pydfnworks/general/dfnworks.py
@@ -229,7 +229,12 @@ class DFNWORKS():
         self.print_log("--> Creating DFN Object: Complete" )
 
     def __del__(self):
-        self.print_log(f"--> {self.local_jobname} completed/exited " )
+        try:
+            print(f"--> {self.local_jobname} completed/exited " )
+            pass
+        except Exception:
+            print("--> Job completed/exited")
+            pass
 
 #         elapsed = time() - self.start_time
 #         time_sec = elapsed


### PR DESCRIPTION
Bug fix for #95 Logger Error with object de-constructor. Removed the print_log since the log file is inaccessible and already contains the information that was going to be printed. Added exception handling.