### PR TITLE
Fix LaGriT merge script bugs in lagrit_merge_mesh.py

### DIFF
--- a/pydfnworks/pydfnworks/dfnGen/meshing/mesh_dfn/lagrit_merge_mesh.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/mesh_dfn/lagrit_merge_mesh.py
@@ -57,7 +57,7 @@ cmo / delete / mo_{1}
     lagrit_input_2 = '# Writing out merged fractures\n'
     if not self.visual_mode:
         lagrit_input_2 += """
-mo / addatt/ cmo_tmp / volume / evol_all
+cmo / addatt / cmo_tmp / volume / evol_all
 math / sum / cmo_tmp / evol_sum / 1 0 0 / cmo_tmp / evol_all """
     lagrit_input_2 += """ 
 cmo select cmo_tmp
@@ -81,6 +81,9 @@ finish
         # self.print_log(f"cpu: {cpu}")
         # self.print_log(current_fractures)
         frac_index += part_size
+        # skip CPUs that received no fractures
+        if not current_fractures:
+            continue
         # write script to merge them in batch
         with open(f'lagrit_scripts/merge_part_{cpu+1}.lgi', 'w') as fout:
             for frac_id in current_fractures:
@@ -117,6 +120,8 @@ cmo / delete / cmo_tmp
     """
     with open('lagrit_scripts/merge_network.lgi', 'w') as f:
         for j in range(1, self.ncpu + 1):
+            if not os.path.isfile(f'lagrit_scripts/merge_part_{j}.lgi'):
+                continue
             f.write(lagrit_input.format(j))
 
         # Append meshes complete


### PR DESCRIPTION
## Summary

- Fix typo on line 60: `mo / addatt/` should be `cmo / addatt /` (`mo` is not a valid LaGriT command)
- Skip writing merge scripts for CPUs that receive no fractures (prevents infinite error loop when `num_fractures <= ncpu`)
- Skip reading nonexistent part files in `create_final_merge_script()`

## Details

When `num_fractures <= ncpu`, `part_size = floor(num_frac/ncpu) + 1` can exceed the fracture count, causing the first CPU to grab all fractures and later CPUs to get an empty list. The empty merge scripts still write the `cmo_tmp` footer, but since no fractures were read, `cmo_tmp` does not exist. LaGriT then loops forever printing `CMO_GET_INFO: Mesh Object does not exist: cmo_tmp`, generating multi-GB dump files.

## Test plan

- [x] Run `two_fracture_case` example with `ncpu=2` (previously hangs, should now complete)
- [x] Run `two_fracture_case` example with `ncpu=1` (should still work as before)
- [x] Run any example with `ncpu < num_fractures` (should be unaffected)

Fixes #142, fixes #143.