### PR TITLE
Add HDF5 parser for PFLOTRAN output (parse_pflotran_h5)

### DIFF
--- a/pydfnworks/pydfnworks/dfnFlow/flow.py
+++ b/pydfnworks/pydfnworks/dfnFlow/flow.py
@@ -34,24 +34,32 @@ def set_flow_solver(self, flow_solver):
         self.print_log(error, 'error')
 
 
-def dfn_flow(self, dump_vtk=True):
+def dfn_flow(self, dump_vtk=True, dump_h5=False):
     """ Run the dfnFlow portion of the workflow
-       
+
     Parameters
     ----------
         self : object
             DFN Class
-        
+
         dump_vtk : bool
-            True - Write out vtk files for flow solutions 
-            False  - Does not write out vtk files for flow solutions 
- 
+            True - Parse PFLOTRAN VTK output into parsed_vtk/ via
+                   parse_pflotran_vtk_python (default).
+            False - Skip VTK parsing.
+        dump_h5 : bool
+            True - Parse PFLOTRAN HDF5 output into parsed_vtk/ via
+                   parse_pflotran_h5. Mesh comes from the .inp via
+                   inp2vtk_python; data come from <base>.h5.
+            False - Skip HDF5 parsing (default).
+
     Returns
     ---------
 
     Notes
     --------
-    Information on individual functions is found therein 
+    Information on individual functions is found therein.
+    dump_vtk and dump_h5 are independent; both can be True to produce
+    parsed output from each source.
     """
 
     self.print_log('=' * 80)
@@ -68,6 +76,8 @@ def dfn_flow(self, dump_vtk=True):
 
         if dump_vtk:
             self.parse_pflotran_vtk_python()
+        if dump_h5:
+            self.parse_pflotran_h5()
         self.pflotran_cleanup()
 
     elif self.flow_solver == "FEHM":

--- a/pydfnworks/pydfnworks/dfnFlow/flow.py
+++ b/pydfnworks/pydfnworks/dfnFlow/flow.py
@@ -43,11 +43,11 @@ def dfn_flow(self, dump_vtk=True, dump_h5=False):
             DFN Class
 
         dump_vtk : bool
-            True - Parse PFLOTRAN VTK output into parsed_vtk/ via
+            True - Parse PFLOTRAN VTK output into pflotran_vtk_outputs/ via
                    parse_pflotran_vtk_python (default).
             False - Skip VTK parsing.
         dump_h5 : bool
-            True - Parse PFLOTRAN HDF5 output into parsed_vtk/ via
+            True - Parse PFLOTRAN HDF5 output into pflotran_vtk_outputs/ via
                    parse_pflotran_h5. Mesh comes from the .inp via
                    inp2vtk_python; data come from <base>.h5.
             False - Skip HDF5 parsing (default).

--- a/pydfnworks/pydfnworks/dfnFlow/pflotran.py
+++ b/pydfnworks/pydfnworks/dfnFlow/pflotran.py
@@ -579,3 +579,165 @@ def parse_pflotran_vtk_python(self, grid_vtk_file=''):
                 f.write(line)
         os.remove(file)
     self.print_log('--> Parsing PFLOTRAN output complete')
+
+
+def _sanitize_vtk_field_name(name):
+    """ Sanitize an HDF5 dataset name so it is a valid legacy VTK SCALARS field name.
+
+    Replaces whitespace and bracket characters with underscores, collapses
+    repeated underscores, and trims leading/trailing underscores.
+    Example: 'Liquid Pressure [Pa]' -> 'Liquid_Pressure_Pa'
+    """
+    out = []
+    for ch in name:
+        if ch.isalnum() or ch == '_':
+            out.append(ch)
+        else:
+            out.append('_')
+    sanitized = ''.join(out)
+    # collapse repeated underscores
+    while '__' in sanitized:
+        sanitized = sanitized.replace('__', '_')
+    return sanitized.strip('_') or 'field'
+
+
+def _time_group_index(group_name):
+    """ Extract the integer time index from a PFLOTRAN HDF5 time group name.
+
+    PFLOTRAN writes top-level groups like '   0 Time  0.00000E+00 d',
+    '   1 Time  1.00000E+02 d', etc. The first whitespace-delimited token
+    is the time index.
+    """
+    try:
+        return int(group_name.strip().split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def parse_pflotran_h5(self, h5_file='', grid_vtk_file=''):
+    """ Parse PFLOTRAN HDF5 output into per-time-step legacy VTK files.
+
+    The mesh is taken from a VTK file derived from the .inp mesh
+    (via inp2vtk_python if not already produced). Solution data is read
+    from PFLOTRAN's main HDF5 output, which contains one group per time
+    step. Every dataset present in a time group is written to the
+    corresponding parsed_vtk/<base>-NNN.vtk file as POINT_DATA scalars.
+
+    Parameters
+    ----------
+        self : object
+            DFN Class
+        h5_file : string
+            Path to the PFLOTRAN HDF5 output file. If empty, defaults to
+            '<local_dfnFlow_file stem>.h5' in the current directory.
+        grid_vtk_file : string
+            Path to a VTK file containing the mesh. If empty, inp2vtk_python
+            is invoked to produce one from self.inp_file.
+
+    Returns
+    --------
+        None
+
+    Notes
+    --------
+        - Dataset names are sanitized for legacy VTK compatibility
+          (spaces and brackets become underscores).
+        - Integer datasets are written with `int` scalar type; everything
+          else is written as `float`.
+        - Output files land in ./parsed_vtk/ to mirror parse_pflotran_vtk_python.
+    """
+    self.print_log('--> Parsing PFLOTRAN HDF5 output with Python')
+
+    if self.flow_solver != "PFLOTRAN":
+        self.print_log("Error. Wrong flow solver requested\n", 'error')
+
+    # Resolve the mesh VTK
+    if grid_vtk_file:
+        self.vtk_file = grid_vtk_file
+    elif not getattr(self, 'vtk_file', None) or not os.path.exists(self.vtk_file):
+        self.inp2vtk_python()
+    grid_file = self.vtk_file
+
+    # Resolve the HDF5 file
+    if not h5_file:
+        h5_file = f"{Path(self.local_dfnFlow_file).stem}.h5"
+    if not os.path.exists(h5_file):
+        self.print_log(f"PFLOTRAN HDF5 file not found: {h5_file}", 'error')
+    self.print_log(f"--> Reading HDF5 data from {h5_file}")
+
+    # Read mesh block from the existing VTK (skip the 3 header lines so we
+    # can swap in our own header; matches parse_pflotran_vtk_python).
+    with open(grid_file, 'r') as f:
+        grid = f.readlines()[3:]
+
+    num_points = None
+    for line in grid:
+        if 'POINTS' in line:
+            num_points = line.strip().split()[1]
+            break
+    if num_points is None:
+        self.print_log(f"Could not find POINTS line in {grid_file}", 'error')
+
+    out_dir = 'parsed_vtk'
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    base = Path(self.local_dfnFlow_file).stem
+    header_lines = [
+        '# vtk DataFile Version 2.0\n',
+        'PFLOTRAN output\n',
+        'ASCII\n',
+    ]
+
+    with h5py.File(h5_file, 'r') as h5:
+        # Keep only the time-step groups (skip anything that doesn't parse).
+        time_groups = []
+        for name in h5.keys():
+            if not isinstance(h5[name], h5py.Group):
+                continue
+            idx = _time_group_index(name)
+            if idx is None:
+                continue
+            time_groups.append((idx, name))
+        time_groups.sort(key=lambda x: x[0])
+
+        if not time_groups:
+            self.print_log(
+                f"No PFLOTRAN time-step groups found in {h5_file}", 'error')
+
+        for idx, group_name in time_groups:
+            group = h5[group_name]
+            out_path = os.path.join(out_dir, f"{base}-{idx:03d}.vtk")
+            self.print_log(f"--> Writing {out_path}")
+            with open(out_path, 'w') as f:
+                for line in header_lines:
+                    f.write(line)
+                for line in grid:
+                    f.write(line)
+                f.write('\n')
+                f.write(f"POINT_DATA {num_points}\n")
+
+                for dset_name in group.keys():
+                    dset = group[dset_name]
+                    if not isinstance(dset, h5py.Dataset):
+                        continue
+                    values = np.asarray(dset[()]).ravel()
+                    if values.size != int(num_points):
+                        self.print_log(
+                            f"Skipping '{dset_name}' in time group {idx}: "
+                            f"size {values.size} != {num_points} mesh points")
+                        continue
+                    field = _sanitize_vtk_field_name(dset_name)
+                    if np.issubdtype(values.dtype, np.integer):
+                        scalar_type = 'int'
+                        fmt = '%d'
+                    else:
+                        scalar_type = 'float'
+                        fmt = '%.8e'
+                    f.write(f"SCALARS {field} {scalar_type} 1\n")
+                    f.write("LOOKUP_TABLE default\n")
+                    for v in values:
+                        f.write(fmt % v)
+                        f.write('\n')
+
+    self.print_log('--> Parsing PFLOTRAN HDF5 output complete')

--- a/pydfnworks/pydfnworks/dfnFlow/pflotran.py
+++ b/pydfnworks/pydfnworks/dfnFlow/pflotran.py
@@ -547,7 +547,7 @@ def parse_pflotran_vtk_python(self, grid_vtk_file=''):
     with open(grid_file, 'r') as f:
         grid = f.readlines()[3:]
 
-    out_dir = 'parsed_vtk'
+    out_dir = 'pflotran_vtk_outputs'
 
     for line in grid:
         if 'POINTS' in line:
@@ -621,7 +621,7 @@ def parse_pflotran_h5(self, h5_file='', grid_vtk_file=''):
     (via inp2vtk_python if not already produced). Solution data is read
     from PFLOTRAN's main HDF5 output, which contains one group per time
     step. Every dataset present in a time group is written to the
-    corresponding parsed_vtk/<base>-NNN.vtk file as POINT_DATA scalars.
+    corresponding pflotran_vtk_outputs/<base>-NNN.vtk file as POINT_DATA scalars.
 
     Parameters
     ----------
@@ -644,7 +644,7 @@ def parse_pflotran_h5(self, h5_file='', grid_vtk_file=''):
           (spaces and brackets become underscores).
         - Integer datasets are written with `int` scalar type; everything
           else is written as `float`.
-        - Output files land in ./parsed_vtk/ to mirror parse_pflotran_vtk_python.
+        - Output files land in ./pflotran_vtk_outputs/ to mirror parse_pflotran_vtk_python.
     """
     self.print_log('--> Parsing PFLOTRAN HDF5 output with Python')
 
@@ -678,7 +678,7 @@ def parse_pflotran_h5(self, h5_file='', grid_vtk_file=''):
     if num_points is None:
         self.print_log(f"Could not find POINTS line in {grid_file}", 'error')
 
-    out_dir = 'parsed_vtk'
+    out_dir = 'pflotran_vtk_outputs'
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 

--- a/pydfnworks/pydfnworks/dfnFlow/pflotran.py
+++ b/pydfnworks/pydfnworks/dfnFlow/pflotran.py
@@ -741,3 +741,4 @@ def parse_pflotran_h5(self, h5_file='', grid_vtk_file=''):
                         f.write('\n')
 
     self.print_log('--> Parsing PFLOTRAN HDF5 output complete')
+

--- a/pydfnworks/pydfnworks/general/dfnworks.py
+++ b/pydfnworks/pydfnworks/general/dfnworks.py
@@ -120,7 +120,7 @@ class DFNWORKS():
     # dfnFlow
     import pydfnworks.dfnFlow
     from pydfnworks.dfnFlow.flow import dfn_flow, create_dfn_flow_links, set_flow_solver
-    from pydfnworks.dfnFlow.pflotran import lagrit2pflotran, pflotran, parse_pflotran_vtk_python, pflotran_cleanup, write_perms_and_correct_volumes_areas, zone2ex, dump_h5_files, correct_uge_file
+    from pydfnworks.dfnFlow.pflotran import lagrit2pflotran, pflotran, parse_pflotran_vtk_python, parse_pflotran_h5, pflotran_cleanup, write_perms_and_correct_volumes_areas, zone2ex, dump_h5_files, correct_uge_file
     from pydfnworks.dfnFlow.fehm import correct_stor_file, fehm
     from pydfnworks.dfnFlow.mass_balance import effective_perm
 


### PR DESCRIPTION
## Summary

- Add `parse_pflotran_h5`, a sibling of `parse_pflotran_vtk_python` that reads PFLOTRAN's per-time-step solution data from its main HDF5 output (`<base>.h5`) instead of from PFLOTRAN's VTK dump. The mesh continues to come from the `.inp` via `inp2vtk_python`; only the solution values change source. Each time-step group in the h5 produces one `pflotran_vtk_outputs/<base>-NNN.vtk` with `POINT_DATA` scalars for every dataset present in the group.
- Add a `dump_h5=False` flag to `dfn_flow()` so users can opt in. `dump_vtk` and `dump_h5` are independent; existing behavior is unchanged unless the user explicitly enables `dump_h5=True`.
- Rename the parser output directory from `parsed_vtk/` to `pflotran_vtk_outputs/` for both the existing VTK parser and the new HDF5 parser. *Heads up*: any downstream code or notebook that hard-coded `parsed_vtk/` needs updating.

## Changes

- `pydfnworks/dfnFlow/pflotran.py`
  - New `parse_pflotran_h5(self, h5_file='', grid_vtk_file='')`.
  - Helpers `_sanitize_vtk_field_name` (turns `"Liquid Pressure [Pa]"` into a legal VTK SCALARS name like `Liquid_Pressure_Pa`) and `_time_group_index` (parses PFLOTRAN's `"   0 Time  0.00000E+00 d"` group names).
  - Integer datasets are written with VTK scalar type `int`; other numerics as `float`.
- `pydfnworks/general/dfnworks.py` — register `parse_pflotran_h5` as a DFN method.
- `pydfnworks/dfnFlow/flow.py` — `dfn_flow()` gains `dump_h5=False`; calls `parse_pflotran_h5` when True. Updated docstring.
- Both parsers now write to `pflotran_vtk_outputs/` instead of `parsed_vtk/`.

## Usage

```python
DFN.dfn_flow(dump_vtk=False, dump_h5=True)
# or both
DFN.dfn_flow(dump_vtk=True, dump_h5=True)