### PR TITLE
UDFM: anisotropic permeability output + robust parallel drivers

### DIFF
--- a/examples/udfm/udfm_multi_material.in
+++ b/examples/udfm/udfm_multi_material.in
@@ -32,6 +32,21 @@ DATASET Permeability
   FILENAME mesh_permeability.h5
 END
 
+DATASET permX
+  FILENAME mesh_permeability.h5
+  HDF5_DATASET_NAME PermeabilityX
+END
+
+DATASET permY
+  FILENAME mesh_permeability.h5
+  HDF5_DATASET_NAME PermeabilityY
+END
+
+DATASET permZ
+  FILENAME mesh_permeability.h5
+  HDF5_DATASET_NAME PermeabilityZ
+END
+
 DATASET Porosity
   FILENAME mesh_porosity.h5
 END
@@ -43,7 +58,8 @@ MATERIAL_PROPERTY fracture
   TORTUOSITY 0.5d0
   CHARACTERISTIC_CURVES default
   PERMEABILITY
-    DATASET Permeability
+    ANISOTROPIC
+    DATASET perm
   /
 END
 
@@ -54,7 +70,8 @@ MATERIAL_PROPERTY matrix
   TORTUOSITY 0.5d0
   CHARACTERISTIC_CURVES default
   PERMEABILITY
-    DATASET Permeability
+    ANISOTROPIC
+    DATASET perm
   /
 END
 

--- a/pydfnworks/pydfnworks/dfnGen/meshing/udfm/map2continuum.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/udfm/map2continuum.py
@@ -9,11 +9,12 @@ import os
 import sys
 import subprocess
 import shutil
+import traceback
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pydfnworks.dfnGen.meshing.mesh_dfn import mesh_dfn_helper as mh
 from pydfnworks.general.logging import local_print_log
 import time
-import multiprocessing as mp
 import pickle
 
 
@@ -839,97 +840,116 @@ def lagrit_strip(num_poly):
         os.remove(f"ex_area{i}.table")
 
 
-def driver_interpolate_parallel(self, num_poly):
-    """ This function drives the parallelization of the area sums upscaling.
-    
+def _fracture_work_order(self, num_poly):
+    """ Return fracture ids ordered largest-surface-area first (LPT
+    scheduling), so a large fracture submitted late cannot serialize the tail
+    of a parallel phase. Falls back to natural order if areas are unavailable.
+    """
+    frac_ids = list(range(1, int(num_poly) + 1))
+    surface_area = getattr(self, "surface_area", None)
+    if surface_area is not None and len(surface_area) >= num_poly:
+        frac_ids.sort(key=lambda f: -surface_area[f - 1])
+    return frac_ids
+
+
+def _run_fracture_jobs(self, job, num_poly, phase_name):
+    """ Run a per-fracture job over all fractures in a thread pool.
+
+    The per-fracture work (upscale_parallel / interpolate_parallel) only
+    writes small text files and waits on LaGriT subprocesses, so threads give
+    full parallelism (the GIL is released during subprocess waits) without the
+    fork()/spawn() hazards of multiprocessing: no forked children that can
+    deadlock on inherited locks (macOS), exceptions propagate to the caller,
+    and an unguarded driver script cannot re-execute.
+
     Parameters
     ----------
         self : object
             DFN Class
-        
+
+        job : callable
+            function of a single fracture id
+
+        num_poly : int
+            Number of fractures
+
+        phase_name : string
+            label used in progress / error messages
+
+    Returns
+    -------
+        None. Calls print_log(..., 'error') (which exits) if any job failed.
+    """
+    frac_ids = _fracture_work_order(self, num_poly)
+    num_workers = max(1, min(int(self.ncpu), int(num_poly)))
+    self.print_log(
+        f"--> {phase_name}: running {num_poly} fracture jobs on "
+        f"{num_workers} workers")
+    failed = []
+    with ThreadPoolExecutor(max_workers=num_workers) as pool:
+        futures = {pool.submit(job, f): f for f in frac_ids}
+        for future in as_completed(futures):
+            f = futures[future]
+            try:
+                future.result()
+            except Exception:
+                failed.append(f)
+                self.print_log(
+                    f"--> Error in {phase_name} job for fracture {f}:\n"
+                    f"{traceback.format_exc()}", 'warning')
+    if failed:
+        self.print_log(
+            f"Error. {phase_name} failed for {len(failed)} fracture(s): "
+            f"{sorted(failed)}. See warnings above for tracebacks.", 'error')
+    self.print_log(f"--> {phase_name}: complete")
+
+
+def driver_interpolate_parallel(self, num_poly):
+    """ This function drives the parallelization of the area sums upscaling.
+
+    Parameters
+    ----------
+        self : object
+            DFN Class
+
         num_poly : int
             Number of fractures
 
     Returns
     -------
         None
-    
+
     Notes
     -----
         None
- 
+
     """
-    frac_index = range(1, int(num_poly + 1))
-    number_of_task = len(frac_index)
-    number_of_processes = self.ncpu
-    tasks_to_accomplish = mp.Queue()
-    tasks_that_are_done = mp.Queue()
-    processes = []
-
-    for i in range(number_of_task):
-        tasks_to_accomplish.put(i + 1)
-
-    # Creating processes
-    for w in range(number_of_processes):
-        p = mp.Process(target=worker_interpolate,
-                       args=(tasks_to_accomplish, tasks_that_are_done))
-        processes.append(p)
-        p.start()
-        tasks_to_accomplish.put('STOP')
-
-    for p in processes:
-        p.join()
-
-    while not tasks_that_are_done.empty():
-        self.print_log(tasks_that_are_done.get())
-
+    _run_fracture_jobs(self, interpolate_parallel, num_poly,
+                       "Fracture interpolation")
     return True
 
 
 def driver_parallel(self, num_poly):
     """ This function drives the parallelization of the area sums upscaling.
-    
+
     Parameters
     ----------
         self : object
             DFN Class
-        
+
         num_poly : int
             Number of fractures
 
     Returns
     -------
         None
-    
+
     Notes
     -----
         None
- 
+
     """
-    frac_index = range(1, int(num_poly + 1))
-    number_of_task = len(frac_index)
-    number_of_processes = self.ncpu
-    tasks_to_accomplish = mp.Queue()
-    tasks_that_are_done = mp.Queue()
-    processes = []
-
-    for i in range(number_of_task):
-        tasks_to_accomplish.put(i + 1)
-
-    # Creating processes
-    for w in range(number_of_processes):
-        p = mp.Process(target=worker,
-                       args=(tasks_to_accomplish, tasks_that_are_done))
-        processes.append(p)
-        p.start()
-        tasks_to_accomplish.put('STOP')
-
-    for p in processes:
-        p.join()
-
-    while not tasks_that_are_done.empty():
-        self.print_log(tasks_that_are_done.get())
-
+    _run_fracture_jobs(self, upscale_parallel, num_poly, "Area-sum upscaling")
     return True
 
 
@@ -981,71 +1001,21 @@ def upscale_parallel(f_id):
     mh.run_lagrit_script(
         f"driver{f_id}.lgi",
         f"lagrit_logs/driver{f_id}",
+        quiet=True,
     )
+    # run_lagrit_script does not raise on failure; verify the expected output
+    # exists so a failed job surfaces here instead of as a missing file in
+    # build_dict.
+    if not os.path.isfile(f"area_sum{f_id}.table"):
+        raise RuntimeError(
+            f"LaGriT area-sum upscaling for fracture {f_id} did not produce "
+            f"area_sum{f_id}.table. See lagrit_logs/driver{f_id}.log")
     # Delete files
     os.remove(f"ex_xyz{f_id}_2.inp")
     os.remove(f"ex_area{f_id}_2.table")
     os.remove(f"frac{f_id}.inp")
     shutil.copy(f"driver{f_id}.lgi", "lagrit_scripts")
     os.remove(f"driver{f_id}.lgi")
-
-
-def worker(tasks_to_accomplish, tasks_that_are_done):
-    """ Worker function for python parallel. See multiprocessing module 
-    documentation for details.
-
-    Parameters
-    ----------
-        tasks_to_accomplish : ?
-            Processes still in queue 
-        
-        tasks_that_are_done : ?
-            Processes complete
-
-    Returns
-    -------
-        None
-
-    Notes
-    -----
-        None
- 
-    """
-    try:
-        for f_id in iter(tasks_to_accomplish.get, 'STOP'):
-            upscale_parallel(f_id)
-    except:
-        pass
-    return True
-
-
-def worker_interpolate(tasks_to_accomplish, tasks_that_are_done):
-    """ Worker function for python parallel. See multiprocessing module 
-    documentation for details.
-
-    Parameters
-    ----------
-        tasks_to_accomplish : ?
-            Processes still in queue 
-        
-        tasks_that_are_done : ?
-            Processes complete
-
-    Returns
-    -------
-        None
-
-    Notes
-    -----
-        None
- 
-    """
-    try:
-        for f_id in iter(tasks_to_accomplish.get, 'STOP'):
-            interpolate_parallel(f_id)
-    except:
-        pass
-    return True
 
 
 def interpolate_parallel(f_id):
@@ -1065,7 +1035,16 @@ def interpolate_parallel(f_id):
     """
 
     mh.run_lagrit_script(f"driver_frac{f_id}.lgi",
-                         f"lagrit_logs/driver_frac{f_id}")
+                         f"lagrit_logs/driver_frac{f_id}",
+                         quiet=True)
+    # run_lagrit_script does not raise on failure; verify the expected
+    # outputs exist so a failed job surfaces here instead of downstream.
+    for outfile in (f"frac{f_id}.inp", f"ex_xyz{f_id}.table",
+                    f"ex_area{f_id}.table"):
+        if not os.path.isfile(outfile):
+            raise RuntimeError(
+                f"LaGriT interpolation for fracture {f_id} did not produce "
+                f"{outfile}. See lagrit_logs/driver_frac{f_id}.log")
     shutil.copy(f"driver_frac{f_id}.lgi", "lagrit_scripts")
     os.remove(f"driver_frac{f_id}.lgi")
 

--- a/pydfnworks/pydfnworks/dfnGen/meshing/udfm/upscale.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/udfm/upscale.py
@@ -131,10 +131,15 @@ def upscale(self, mat_perm, mat_por, tag_mesh=True, path='../'):
                 perm_tensor += (phi * (b)**2 * Omega)
             perm_tensor *= 1. / 12
 
-            # Calculate eigenvalues
-            permX[i - 1] = np.linalg.eigvals(perm_tensor)[0]
-            permY[i - 1] = np.linalg.eigvals(perm_tensor)[1]
-            permZ[i - 1] = np.linalg.eigvals(perm_tensor)[2]
+            # Axis components of the permeability tensor. The diagonal equals
+            # the principal components projected onto the coordinate axes
+            # (sum_j lambda_j (v_j . e_i)^2): exact for fractures orthogonal to
+            # a coordinate axis (Sweeney et al. 2020, Fig. 1) and the natural
+            # projection otherwise. Note np.linalg.eigvals returns eigenvalues
+            # in arbitrary order, so it must not be used for X/Y/Z mapping.
+            permX[i - 1] = perm_tensor[0][0]
+            permY[i - 1] = perm_tensor[1][1]
+            permZ[i - 1] = perm_tensor[2][2]
 
             # Arithmetic average of matrix perm
             permX[i - 1] += (1 - phi_sum) * mat_perm
@@ -150,21 +155,23 @@ def upscale(self, mat_perm, mat_por, tag_mesh=True, path='../'):
 
             # See Sweeney et al. 2019 Computational Geoscience
             for j in range(len(f_dict[i])):
+                # track the angle closest to 45 degrees (largest staircase
+                # error). Store the distance-to-45, not the angle itself.
                 n1_temp = self.normal_vectors[f_dict[i][j][0] - 1][0]
-                theta1_t = m.degrees(m.acos(n1_temp)) % 90
+                theta1_t = m.degrees(m.acos(min(1.0, max(-1.0, n1_temp)))) % 90
                 if abs(theta1_t - 45) <= min_n1:
                     theta1 = theta1_t
-                    min_n1 = theta1_t
+                    min_n1 = abs(theta1_t - 45)
                 n2_temp = self.normal_vectors[f_dict[i][j][0] - 1][1]
-                theta2_t = m.degrees(m.acos(n2_temp)) % 90
+                theta2_t = m.degrees(m.acos(min(1.0, max(-1.0, n2_temp)))) % 90
                 if abs(theta2_t - 45) <= min_n2:
                     theta2 = theta2_t
-                    min_n2 = theta2_t
+                    min_n2 = abs(theta2_t - 45)
                 n3_temp = self.normal_vectors[f_dict[i][j][0] - 1][2]
-                theta3_t = m.degrees(m.acos(n3_temp)) % 90
+                theta3_t = m.degrees(m.acos(min(1.0, max(-1.0, n3_temp)))) % 90
                 if abs(theta3_t - 45) <= min_n3:
                     theta3 = theta3_t
-                    min_n3 = theta3_t
+                    min_n3 = abs(theta3_t - 45)
 
             sl = (2 * 2**(1. / 2) - 1) / -45.0
             b = 2 * 2**(1. / 2)
@@ -217,14 +224,15 @@ def upscale(self, mat_perm, mat_por, tag_mesh=True, path='../'):
         dataset_name = 'Permeability'
         h5dset = h5file.create_dataset(dataset_name, data=perm_var)
 
-        #dataset_name = 'Perm_X'
-        #h5dset = h5file.create_dataset(dataset_name, data = permX)
-
-        #dataset_name = 'Perm_Y'
-        #h5set = h5file.create_dataset(dataset_name, data = permY)
-
-        #dataset_name = 'Perm_Z'
-        #h5set = h5file.create_dataset(dataset_name, data = permZ)
+        # Anisotropic components (Sweeney et al. 2020, Eq. 3 / Fig. 1). For
+        # networks where fractures are orthogonal to the coordinate axes these
+        # should be preferred over the isotropic maximum, which spuriously
+        # assigns the in-plane permeability to the fracture-normal direction.
+        # Use in PFLOTRAN with PERMEABILITY / ANISOTROPIC / DATASET perm and
+        # datasets permX/permY/permZ pointing at these names.
+        h5dset = h5file.create_dataset('PermeabilityX', data=permX)
+        h5dset = h5file.create_dataset('PermeabilityY', data=permY)
+        h5dset = h5file.create_dataset('PermeabilityZ', data=permZ)
         h5file.close()
 
         h5file = h5py.File(poros_filename, mode='w')

--- a/pydfnworks/pydfnworks/dfnGen/meshing/udfm/upscale.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/udfm/upscale.py
@@ -197,10 +197,12 @@ def upscale(self, mat_perm, mat_por, tag_mesh=True, path='../'):
 
         if self.flow_solver == "FEHM":
             with open("perm_fehm.dat", "a") as f:
+                # kx ky kz from the tensor diagonal (was 3 copies of the
+                # isotropic maximum, which conducts across the fracture plane)
                 f.write(
                     str(i) + " " + str(i) + " " + "1" + " " +
-                    str(perm_var[i - 1]) + " " + str(perm_var[i - 1]) + " " +
-                    str(perm_var[i - 1]) + "\n")
+                    str(permX[i - 1]) + " " + str(permY[i - 1]) + " " +
+                    str(permZ[i - 1]) + "\n")
             with open("rock_fehm.dat", "a") as g:
                 g.write(
                     str(i) + " " + str(i) + " " + "1" + " " + "2165." + " " +


### PR DESCRIPTION
## Problem
UDFM flow and BTC no longer matched the DFN (verified +3.1% overestimate in
effective permeability on the 4_user_rects case), and the per-fracture parallel
phases intermittently never finished on macOS, with failures swallowed silently.

## Root causes & fixes
1. **Isotropic permeability collapse** — `upscale.py` wrote only
   `Permeability = max(eigenvalues)`, so fracture cells conducted their in-plane
   permeability in the fracture-normal direction too. Now also writes
   `PermeabilityX/Y/Z` from the permeability-tensor **diagonal** (the principal
   components projected onto the coordinate axes — exact for axis-aligned
   fractures, Sweeney et al. 2020 Fig. 1). The old commented-out block could not
   simply be restored: `np.linalg.eigvals` returns eigenvalues in arbitrary
   order, so it never axis-mapped. Example deck updated to
   `PERMEABILITY ANISOTROPIC`; iso dataset still written for existing decks.
   `perm_fehm.dat` gets the same diagonal (kx ky kz).
2. **Staircase correction factor** — closest-to-45° tracking stored the angle
   instead of the distance-to-45 (broken for multi-fracture cells); acos input
   now clamped against rounding.
3. **Parallel phases** — mp.Process+Queue pools on the global fork() start
   method (macOS: children deadlock on inherited locks → parent join() hangs
   forever; bare `except: pass` hid every failure). The per-fracture work is
   LaGriT-subprocess-bound, so both phases now use a ThreadPoolExecutor:
   full parallelism, exceptions propagate with tracebacks, run aborts listing
   failed fractures, expected LaGriT outputs verified. Load balance improved by
   submitting largest fractures first (LPT).

## Verification (4_user_rects, PFLOTRAN steady flow)
| | k_eff [m²] | vs DFN |
|---|---|---|
| DFN reference | 4.07304e-18 | — |
| UDFM isotropic (before) | 4.19937e-18 | +3.10% |
| UDFM anisotropic (after) | 4.07112e-18 | **−0.05%** |

Threaded parallel rerun: results bit-identical to the process-pool run.

## Note
`run_meshing.py` still sets `mp.set_start_method("fork")` globally (same hang
class for parallel meshing) — addressed separately.