### PR TITLE
Meshing: thread-pool parallelism; remove global fork() start method

### DIFF
--- a/pydfnworks/pydfnworks/dfnGen/meshing/mesh_dfn/run_meshing.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/mesh_dfn/run_meshing.py
@@ -10,11 +10,10 @@ import os
 import sys
 import timeit
 import glob
+import threading
 
 import numpy as np
-import multiprocessing as mp
-
-mp.set_start_method("fork")
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from shutil import copy, rmtree
 from numpy import genfromtxt
@@ -193,12 +192,10 @@ def mesh_fracture(fracture_id, visual_mode, num_frac, r_fram, quiet):
 
     """
 
-    # get current process information
+    # get current worker information (thread name is e.g. 'mesh_worker_3')
     try:
-        p = mp.current_process()
-        _, cpu_id = p.name.split("-")
-        cpu_id = int(cpu_id)
-    except:
+        cpu_id = int(threading.current_thread().name.split("_")[-1])
+    except (ValueError, IndexError):
         cpu_id = 1
 
     # get leading digits
@@ -354,38 +351,48 @@ def mesh_fractures_header(self, quiet=True):
         f"--> Triangulating {self.num_frac} fractures using {self.ncpu} processors\n"
     )
 
-    pool = mp.Pool(min(self.num_frac, self.ncpu))
+    # The per-fracture work is subprocess-bound (LaGriT + connectivity check),
+    # so a thread pool gives full parallelism (the GIL is released during
+    # subprocess waits) without the fork()/spawn() hazards of multiprocessing
+    # (forked children deadlocking on inherited locks on macOS left these jobs
+    # hanging forever). Fractures are submitted largest-first (LPT) so a big
+    # fracture at the tail cannot serialize the run.
     result_list = []
 
-    def log_result(result):
-        # This is called whenever foo_pool(i) returns a result.
-        # result_list is modified only by the main process, not the pool workers.
-        result_list.append(result)
-        if result[1] != 0:
-            pool.terminate()
-            # If a run fails, kill all other processes, and clean up the directory
-            names = [
-                "poly_*.inp",
-                "mesh_poly_*.lgi",
-                "parameters_*.mlgi",
-                "intersections_*.inp",
-            ]
-            for name in names:
-                files_to_remove = glob.glob(name)
-                for f in files_to_remove:
-                    os.remove(f)
+    fracture_list = list(self.fracture_list)
+    surface_area = getattr(self, "surface_area", None)
+    if surface_area is not None and len(surface_area) >= max(fracture_list):
+        fracture_list.sort(key=lambda f: -surface_area[f - 1])
 
-    # get leading digits
-    digits = len(str(self.num_frac))
-
-    for i in self.fracture_list:
-        pool.apply_async(mesh_fracture,
-                         args=(i, self.visual_mode, self.num_frac, self.r_fram,
-                               quiet),
-                         callback=log_result)
-
-    pool.close()
-    pool.join()
+    num_workers = max(1, min(len(fracture_list), self.ncpu))
+    with ThreadPoolExecutor(max_workers=num_workers,
+                            thread_name_prefix="mesh_worker") as pool:
+        futures = {
+            pool.submit(mesh_fracture, i, self.visual_mode, self.num_frac,
+                        self.r_fram, quiet): i
+            for i in fracture_list
+        }
+        for future in as_completed(futures):
+            result = future.result()
+            result_list.append(result)
+            if result[1] != 0:
+                # A fracture failed: cancel pending jobs (in-flight LaGriT
+                # runs finish, then are ignored) and clean up the directory.
+                for f_pending in futures:
+                    f_pending.cancel()
+                names = [
+                    "poly_*.inp",
+                    "mesh_poly_*.lgi",
+                    "parameters_*.mlgi",
+                    "intersections_*.inp",
+                ]
+                for name in names:
+                    for f in glob.glob(name):
+                        try:
+                            os.remove(f)
+                        except OSError:
+                            pass
+                break
 
     elapsed = timeit.default_timer() - t_all
     self.print_log('--> Triangulating Polygons: Complete\n')
@@ -570,11 +577,10 @@ def merge_the_fractures(ncpu):
 
     jobs = range(1, ncpu + 1)
     tic = timeit.default_timer()
-    pool = mp.Pool(ncpu)
-    outputs = pool.map(merge_worker, jobs)
-    pool.close()
-    pool.join()
-    pool.terminate()
+    # merge_worker only waits on a LaGriT subprocess -> thread pool suffices
+    with ThreadPoolExecutor(max_workers=ncpu,
+                            thread_name_prefix="merge_worker") as pool:
+        outputs = list(pool.map(merge_worker, jobs))
     elapsed = timeit.default_timer() - tic
     local_print_log(
         f"--> Initial merging complete. Time elapsed: {elapsed:.2e} seconds."

--- a/pydfnworks/pydfnworks/dfnGen/meshing/udfm/map2continuum.py
+++ b/pydfnworks/pydfnworks/dfnGen/meshing/udfm/map2continuum.py
@@ -1073,8 +1073,11 @@ def build_dict(self, num_poly, delete_files):
     """
     f_dict = {}
     for i in range(1, num_poly + 1):
-        imts = np.genfromtxt(f"area_sum{i}.table", skip_header=4)[:, 0]
-        area_sums = np.genfromtxt(f"area_sum{i}.table", skip_header=4)[:, 1]
+        # reshape so a single-row table (fracture intersecting one control
+        # volume) still indexes as 2D; genfromtxt returns 1D in that case
+        data = np.genfromtxt(f"area_sum{i}.table", skip_header=4).reshape(-1, 2)
+        imts = data[:, 0]
+        area_sums = data[:, 1]
         for j in range(len(imts)):
             if int(float(imts[j])) != (num_poly + 1) and float(
                     area_sums[j]) > 0:

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -393,7 +393,11 @@ def run_graph_transport(self,
         inputs = []
 
         tic = timeit.default_timer()
-        pool = mp.Pool(min(self.ncpu, nparticles))
+        # Particle tracking is Python-compute-bound, so real processes are
+        # needed. Use an explicit fork context: the previous global
+        # mp.set_start_method('fork') (in run_meshing) was removed, and the
+        # default 'spawn' on macOS would re-import unguarded driver scripts.
+        pool = mp.get_context("fork").Pool(min(self.ncpu, nparticles))
 
         particles = []
 

--- a/pydfnworks/pydfnworks/dfnGraph/transport/io.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/io.py
@@ -127,7 +127,9 @@ def dump_trajectories(particles, num_cpu, single_file=True):
         if not os.path.isdir('trajectories'):
             os.mkdir('trajectories')
         tic = timeit.default_timer()
-        pool = mp.Pool(num_cpu)
+        # explicit fork context: see graph_transport.py -- the global
+        # set_start_method('fork') side effect was removed from run_meshing
+        pool = mp.get_context("fork").Pool(num_cpu)
         particles = pool.map(dump_trajectory, particles)
         pool.close()
         pool.join()


### PR DESCRIPTION
## Problem
`run_meshing.py` set `mp.set_start_method("fork")` globally at import time.
fork() on macOS after numpy/matplotlib/h5py/logging are loaded can deadlock
children on locks held at fork time, leaving `pool.join()` blocked forever —
the intermittent "meshing never finishes" hangs. The import-time side effect
also changed multiprocessing behavior for every consumer of pydfnworks, and
raises `RuntimeError` if any other library sets the start method first.

## Fix (same treatment as the UDFM parallel drivers in #150)
- **`mesh_fractures_header`**: the per-fracture work is subprocess-bound
  (LaGriT + connectivity check), so `ThreadPoolExecutor` replaces `mp.Pool` —
  same parallelism (the GIL is released during subprocess waits), no fork
  hazards, and worker exceptions propagate instead of vanishing.
- **Load balance**: fractures are submitted largest-surface-area first (LPT
  scheduling), so a large fracture landing late can no longer serialize the
  tail of the run.
- **Early-abort preserved**: on the first failed fracture, pending jobs are
  cancelled (in-flight LaGriT runs finish and are ignored) and the directory
  is cleaned, matching the old `pool.terminate()` behavior.
- **`merge_the_fractures`**: thread-pool map; merge workers only wait on
  LaGriT.
- **Graph transport keeps real processes** (particle tracking is
  Python-compute-bound): its pools now use an explicit, local
  `mp.get_context("fork").Pool`, preserving prior behavior with no global
  start-method mutation (the default spawn would re-import unguarded driver
  scripts).
- Worker ids in log messages now derive from thread names.

## Also included
- `build_dict` (UDFM): `np.genfromtxt` returns a 1D array for a single-line
  `area_sum` table (a fracture intersecting exactly one control volume), so
  `[:, 0]` raised `IndexError`. Now reshaped to `(-1, 2)` and read once;
  behavior unchanged for multi-row tables.

## Verification
- 4_user_rects DFN driver end-to-end: parallel triangulation and merge clean
  ("No meshing issues detected"), k_eff bit-identical to the process-pool
  runs (4.07304e-18 m²).
- Graph transport with `ncpu=2`: 200/200 particles complete through the
  explicit fork-context pool.
- Single-row and multi-row `area_sum` table parsing verified.