### PR TITLE
Seed NumPy and random generators from DFN.params['seed']

### DIFF
--- a/pydfnworks/pydfnworks/dfnGen/generation/generator.py
+++ b/pydfnworks/pydfnworks/dfnGen/generation/generator.py
@@ -136,6 +136,9 @@ def create_network(self):
     After generation is complete, this script checks whether the generation of the fracture network failed or succeeded based on the existence of the file params.txt. 
     '''
     self.print_log('--> Running DFNGEN')
+    # seed the pydfnworks generators (NumPy / random) before any Python-side
+    # randomness is drawn, e.g. in assign_hydraulic_properties() below
+    self.set_seed()
     os.chdir(self.jobname)
     cmd = os.environ[
         'DFNGEN_EXE'] + ' ' + 'dfnGen_output/' + self.local_dfnGen_file[:

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -52,7 +52,7 @@ def track_particle(data, verbose=False):
                         data["matrix_diffusivity"], data["fracture_spacing"],
                         data["trans_prob"], data["transfer_time"],
                         data["cp_flag"], data["control_planes"],
-                        data["direction"])
+                        data["direction"], data["seed"])
 
     # # get current process information
     global nbrs_dict
@@ -343,6 +343,13 @@ def run_graph_transport(self,
     self.print_log("--> Getting initial Conditions")
     ip, nparticles = get_initial_posititions(G, initial_positions, nparticles)
 
+    # DFN seed: each particle derives its own independent stream from this, so
+    # the ensemble is reproducible and controlled by DFN.params['seed'].
+    seed = getattr(self, "seed", None)
+    if seed is None:
+        seed = self.params['seed']['value'] if hasattr(self, "params") else 0
+    self.print_log(f"--> Particle random seeds derived from seed {seed}")
+
     self.print_log(f"--> Starting particle tracking for {nparticles} particles")
 
     if dump_traj:
@@ -370,7 +377,7 @@ def run_graph_transport(self,
             particle = Particle(i, ip[i], tdrw_flag, matrix_porosity,
                                 matrix_diffusivity, fracture_spacing,
                                 trans_prob, transfer_time, control_plane_flag,
-                                control_planes, direction)
+                                control_planes, direction, seed)
             particle.track(G, nbrs_dict)
             particles.append(particle)
 
@@ -417,6 +424,7 @@ def run_graph_transport(self,
             data["cp_flag"] = control_plane_flag
             data["control_planes"] = control_planes
             data["direction"] = direction
+            data["seed"] = seed
             pool.apply_async(track_particle,
                              args=(data, ),
                              callback=gather_output)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
@@ -19,8 +19,11 @@ class Particle():
 
     def __init__(self, particle_number, ip, tdrw_flag, matrix_porosity,
                  matrix_diffusivity, fracture_spacing, trans_prob,
-                 transfer_time, cp_flag, control_planes, direction):
+                 transfer_time, cp_flag, control_planes, direction, seed=0):
         self.particle_number = particle_number
+        # every particle gets its own independent random stream, derived from
+        # the DFN seed so the whole ensemble is reproducible (see track())
+        self.seed = seed
         self.ip = ip
         self.curr_node = ip
         self.curr_velocity = 0
@@ -264,7 +267,14 @@ class Particle():
         -------
             None
         """
-        np.random.seed(self.particle_number)
+        # Each particle needs its own seed: particles are tracked in forked
+        # worker processes, which would otherwise inherit and replay an
+        # identical random stream. Mixing the DFN seed with the particle number
+        # through a SeedSequence keeps the per-particle streams independent
+        # while making the ensemble reproducible from DFN.params['seed'].
+        particle_seed = np.random.SeedSequence(
+            [int(self.seed), int(self.particle_number)]).generate_state(1)[0]
+        np.random.seed(particle_seed)
         self.initalize(G)
         while not self.exit_flag:
             self.advect(G, nbrs_dict)

--- a/pydfnworks/pydfnworks/general/dfnworks.py
+++ b/pydfnworks/pydfnworks/general/dfnworks.py
@@ -64,7 +64,7 @@ class DFNWORKS():
     from pydfnworks.general.legal import legal
 
     from pydfnworks.general.images import failure, success
-    from pydfnworks.general.general_functions import dump_time, print_run_time, print_parameters, go_home, to_pickle, from_pickle,  call_executable, check_input_paths
+    from pydfnworks.general.general_functions import dump_time, print_run_time, print_parameters, go_home, to_pickle, from_pickle,  call_executable, check_input_paths, set_seed
     from pydfnworks.general.logging import initialize_log_file, print_log
 
 

--- a/pydfnworks/pydfnworks/general/general_functions.py
+++ b/pydfnworks/pydfnworks/general/general_functions.py
@@ -5,9 +5,12 @@ from time import time
 import subprocess
 import io
 import logging
+import random
 import select
 import subprocess
 import sys
+
+import numpy as np
 
 from pydfnworks.general.logging import local_print_log
 
@@ -40,6 +43,70 @@ def check_input_paths(self):
             self.print_log(f'Pickle file path is not valid:\n{self.pickle_filename}\n', 'error')
 
     self.print_log("* Checking input paths: Complete")
+
+def set_seed(self, seed=None):
+    ''' Initialize the pydfnworks pseudorandom number generators (NumPy and the
+    Python random module) from the DFN seed.
+
+    Parameters
+    -----------------
+        self : object
+            DFN Class
+
+        seed : int
+            Seed to initialize the generators with. If None (default), the value
+            of self.params['seed']['value'] is used.
+
+    Returns
+    -------------
+        seed : int
+            The seed the generators were initialized with.
+
+    Notes
+    -------------
+        1. Randomness on the Python side of dfnWorks (hydraulic property
+        distributions, Poisson-disc meshing, plot sub-sampling) is drawn from
+        these two global generators, so seeding them makes those values
+        reproducible from run to run.
+
+        2. Following the dfnGen convention, a seed of 0 means "seed off the
+        clock", i.e. produce a unique realization. In that case a seed is drawn
+        from system entropy and reported, so the pydfnworks-side values can be
+        reproduced later by setting DFN.params['seed']['value'] to the reported
+        number.
+
+        3. This does not change the seed used by the dfnGen executable. That
+        seed is read from the input file written by check_input().
+    '''
+    if seed is None:
+        seed = self.params['seed']['value']
+    seed = int(seed)
+
+    if seed < 0:
+        self.print_log(
+            f"Error. seed must be non-negative. Value provided: {seed}",
+            'error')
+
+    if seed == 0:
+        # dfnGen convention: 0 means seed off the clock (unique realization).
+        # Draw one explicitly so the values used can be reported and repeated.
+        seed = random.SystemRandom().randint(1, 2**32 - 1)
+        self.print_log(
+            "--> seed is 0, pydfnworks random number generators are seeded off the clock"
+        )
+        self.print_log(
+            f"--> Set DFN.params['seed']['value'] = {seed} to reproduce these values"
+        )
+    else:
+        self.print_log(
+            f"--> Initializing pydfnworks random number generators with seed {seed}"
+        )
+
+    np.random.seed(seed)
+    random.seed(seed)
+    self.seed = seed
+    return seed
+
 
 def call_executable(self, command):
     ''' Calls subprocess.run to call compiled executables like dfnGen, PFLOTRAN, LaGriT, etc.


### PR DESCRIPTION
Closes #140

## Problem
Python-side randomness in pydfnworks was drawn from the unseeded global NumPy
and `random` generators, so hydraulic property distributions, Poisson-disc
meshing, and plot sub-sampling varied between runs even with `params['seed']`
set and the fracture network itself reproducible.

Graph transport was worse: it reseeded NumPy with `np.random.seed(particle_number)`
at the start of every particle, so transport randomness was identical for *every*
seed, and any global seeding was discarded.

## Changes
- **`DFN.set_seed()`** (`general_functions.py`): seeds both `np.random` and
  `random` from `params['seed']['value']` and records it on `self.seed`. Called
  at the start of `create_network()`, before `assign_hydraulic_properties()`
  draws anything. Accepts an explicit override.
- **Seed 0** keeps its dfnGen meaning ("seed off the clock"): a seed is drawn
  from system entropy and *reported*, so a realization can be reproduced
  afterwards by setting `params['seed']['value']` to that number.
- **Per-particle streams** derive from `SeedSequence([seed, particle_number])` —
  still independent per particle (required: forked workers would otherwise
  replay an identical stream), now controlled by the DFN seed. Threaded through
  both the serial and parallel paths.
- The dfnGen executable's own seed is untouched (read from the input file
  written by `check_input()`).

## Verified coverage
Swept all of pydfnworks for stochastic sources. Covered by the global seed:
hydraulic `distributions.py` / `old_hydraulic_properties.py`
(`np.random.normal`, `.exponential`), `poisson_functions.py`
(`random.random`, `shuffle`), `plot_fracture_orientations.py`
(`random.choices`). Covered by the particle stream: `particle.py`
(`np.random.choice`), `tdrw.py` (`np.random.uniform`). Not applicable:
`mapdfn_ecpm/transformations.py` random helpers are never called, and
`output_report/distributions.py` `exponential`/`lognormal` are analytic
PDF/CDF, not sampling. No `default_rng`, `RandomState`, `scipy.stats`
sampling, `secrets`, or `uuid` anywhere.

## Verification
Seeding: same seed reproduces `np.random.normal`/`.exponential`,
`random.random`, `random.choices`; different seeds diverge; explicit override
honored; seed 0 draws distinct, in-range seeds.

Transport (112-fracture `graph_transport` network, 300 particles): per-particle
streams remain distinct (293 unique travel times of 300), identical results
across runs with the same seed, different seeds give different ensembles, and
**serial == `ncpu=4`** — previously the ensemble could depend on worker count.

## Note
Graph-transport output changes for existing users: a given seed now yields a
different but reproducible ensemble than before. Statistically equivalent, not
bitwise identical.