### PR TITLE
docs: list the real pydfnworks dependencies

### DIFF
--- a/Documentation/sphinx-docs/source/setup.rst
+++ b/Documentation/sphinx-docs/source/setup.rst
@@ -241,7 +241,11 @@ Python
 
 pydfnworks uses Python 3. We recommend using 
 the Anaconda 3 distribution of Python, available at https://www.continuum.io/. 
-pydfnworks requires the following python modules: ``numpy``, ``h5py``, ``scipy``, ``matplotlib``,  ``multiprocessing``, ``argparse``, ``shutil``, ``os``, ``sys``, ``networkx``, ``subprocess``, ``glob``, ``networkx``, ``fpdf``, and ``re``.
+pydfnworks requires the following python modules: ``numpy``, ``networkx``, ``h5py``, ``scipy``, ``matplotlib``, ``mplstereonet``, ``fpdf``, ``seaborn``, ``pyvtk``, and ``mpmath``. They are listed in ``pydfnworks/requirements.txt`` and are installed automatically with pydfnworks, or can be installed directly with
+
+.. code-block:: bash
+
+    pip install -r pydfnworks/requirements.txt
 
 
 LaGriT

--- a/README.md
+++ b/README.md
@@ -82,7 +82,14 @@ dfnWorks currently runs on Macs and Unix machine running Ubuntu.
 
 pydfnworks uses Python 3. We recommend using 
 the Anaconda 3 distribution of Python, available at https://www.continuum.io/. 
-pydfnworks requires the following python modules: ``numpy``, ``h5py``, ``scipy``, ``matplotlib``,  ``multiprocessing``, ``argparse``, ``shutil``, ``os``, ``sys``, ``networkx``, ``subprocess``, ``glob``, ``mplstereonet``, ``fpdf``, and ``re``.
+pydfnworks requires the following python modules: ``numpy``, ``networkx``,
+``h5py``, ``scipy``, ``matplotlib``, ``mplstereonet``, ``fpdf``, ``seaborn``,
+``pyvtk``, and ``mpmath``. They are listed in ``pydfnworks/requirements.txt`` and
+are installed automatically with pydfnworks, or can be installed directly with
+
+```bash
+pip install -r pydfnworks/requirements.txt
+```
 
 
 ### LaGriT


### PR DESCRIPTION
Closes #99

## Problem
The install instructions tell users to `pip install` standard-library modules —
`multiprocessing`, `argparse`, `shutil`, `os`, `sys`, `subprocess`, `glob`, `re` —
none of which can be installed from PyPI. This is the first thing a new user hits.

While fixing it I found the list is wrong in the other direction too: it **omits
three packages pydfnworks actually imports** — `seaborn`, `pyvtk`, and `mpmath`
(verified: each has a real import site in the package). The sphinx copy also
listed `networkx` twice and dropped `mplstereonet` entirely.

## Fix
`README.md` and `Documentation/sphinx-docs/source/setup.rst` now both list the
actual contents of `pydfnworks/requirements.txt` and point at that file as the
source of truth, so the two can't drift again:

```
numpy, networkx, h5py, scipy, matplotlib, mplstereonet, fpdf, seaborn, pyvtk, mpmath
```

plus a `pip install -r pydfnworks/requirements.txt` snippet.