### PR TITLE
Add strike/dip and trend/plunge of fracture normals to the DFN object

### DIFF
--- a/pydfnworks/pydfnworks/dfnGen/generation/orientations.py
+++ b/pydfnworks/pydfnworks/dfnGen/generation/orientations.py
@@ -1,0 +1,164 @@
+"""
+.. module:: orientations.py
+   :synopsis: Convert fracture normal vectors into the orientation conventions
+              used in structural geology -- strike / dip / dip direction of the
+              fracture plane, and trend / plunge of the pole (normal).
+
+All functions use a right-handed ENU coordinate system (x = East, y = North,
+z = Up), and report the lower-hemisphere representation, which is the standard
+convention for stereonet plotting.
+"""
+
+import numpy as np
+
+
+def normals_to_lower_hemisphere(normals):
+    """ Return normals flipped, as needed, into the lower hemisphere.
+
+    Parameters
+    ----------
+        normals : array-like
+            (N, 3) array of normal vectors. A single (3,) vector is accepted and
+            promoted to (1, 3).
+
+    Returns
+    -------
+        normals : numpy array
+            (N, 3) array of normals, all with a non-positive z component.
+
+    Notes
+    -----
+        A copy is returned; the input array is never modified in place.
+    """
+    normals = np.array(normals, dtype=float, copy=True)
+    if normals.ndim == 1:
+        normals = normals[np.newaxis, :]
+    # z is "up": flip any normal pointing into the upper hemisphere
+    flip = normals[:, 2] > 0
+    normals[flip] *= -1.0
+    return normals
+
+
+def normals_to_strike_dip(normals):
+    """ Convert fracture plane normals to strike and dip (right-hand rule).
+
+    Parameters
+    ----------
+        normals : array-like
+            (N, 3) array of normal vectors (nx, ny, nz) in a right-handed ENU
+            system (x = East, y = North, z = Up). Need not be normalized.
+
+    Returns
+    -------
+        strikes : numpy array
+            Strike azimuths in degrees, clockwise from North, 0 - 360.
+
+        dips : numpy array
+            Dip angles from horizontal in degrees, 0 - 90.
+
+        dip_dirs : numpy array
+            Dip directions (azimuth of the down-dip line) in degrees, 0 - 360.
+
+    Notes
+    -----
+        Strike follows the right-hand rule: it is 90 degrees counter-clockwise
+        from the dip direction.
+    """
+    n = normals_to_lower_hemisphere(normals)
+    n /= np.linalg.norm(n, axis=1)[:, np.newaxis]
+
+    nx = n[:, 0]
+    ny = n[:, 1]
+    nz = n[:, 2]
+
+    # dip: angle between the plane and horizontal
+    dip = np.degrees(np.arctan2(np.sqrt(nx**2 + ny**2), np.abs(nz)))
+    # dip direction: opposite the horizontal projection of the normal.
+    # arctan2(East, North) gives an azimuth clockwise from North.
+    dip_dir = np.degrees(np.arctan2(-nx, -ny)) % 360.0
+    # strike: 90 degrees counter-clockwise from dip direction
+    strike = (dip_dir - 90.0) % 360.0
+
+    return strike, dip, dip_dir
+
+
+def normals_to_trend_plunge(normals):
+    """ Convert fracture plane normals to the trend and plunge of the pole.
+
+    Parameters
+    ----------
+        normals : array-like
+            (N, 3) array of normal vectors (nx, ny, nz) in a right-handed ENU
+            system (x = East, y = North, z = Up). Need not be normalized.
+
+    Returns
+    -------
+        trends : numpy array
+            Trend (azimuth) of the pole in degrees, clockwise from North,
+            0 - 360.
+
+        plunges : numpy array
+            Plunge of the pole below horizontal in degrees, 0 - 90.
+
+    Notes
+    -----
+        The pole of a plane is its normal. Because the lower-hemisphere
+        convention is used, the returned values satisfy
+        plunge = 90 - dip and trend = (dip direction + 180) % 360.
+    """
+    n = normals_to_lower_hemisphere(normals)
+    n /= np.linalg.norm(n, axis=1)[:, np.newaxis]
+
+    nx = n[:, 0]
+    ny = n[:, 1]
+    nz = n[:, 2]
+
+    # nz <= 0 by construction, so the plunge is non-negative.
+    # adding 0.0 turns the -0.0 of a horizontal pole into 0.0
+    plunge = np.degrees(np.arcsin(np.clip(-nz, -1.0, 1.0))) + 0.0
+    trend = np.degrees(np.arctan2(nx, ny)) % 360.0
+
+    return trend, plunge
+
+
+def get_fracture_orientations(self):
+    """ Compute the orientation of every fracture in the network and attach the
+    results to the DFN object.
+
+    Parameters
+    ----------
+        self : object
+            DFN Class
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        Sets the following attributes, each a numpy array with one entry per
+        fracture, ordered to match self.normal_vectors:
+
+        * self.strike : strike azimuth of the fracture plane [degrees, 0 - 360]
+        * self.dip : dip of the fracture plane below horizontal [degrees, 0 - 90]
+        * self.dip_direction : azimuth of the down-dip line [degrees, 0 - 360]
+        * self.trend : trend of the pole (normal) [degrees, 0 - 360]
+        * self.plunge : plunge of the pole (normal) [degrees, 0 - 90]
+
+        Uses the lower-hemisphere convention, so plunge = 90 - dip. The
+        fracture normals are not modified.
+    """
+    normals = getattr(self, "normal_vectors", None)
+    if normals is None:
+        self.print_log(
+            "Error. Fracture normal vectors are not defined. Orientations "
+            "require normal_vectors, which is set when the network is created.",
+            'error')
+        return
+
+    self.print_log("--> Computing fracture orientations")
+    self.strike, self.dip, self.dip_direction = normals_to_strike_dip(normals)
+    self.trend, self.plunge = normals_to_trend_plunge(normals)
+    self.print_log(
+        "--> Computing fracture orientations: Complete. Attributes set: "
+        "strike, dip, dip_direction, trend, plunge")

--- a/pydfnworks/pydfnworks/dfnGen/generation/output_report/plot_fracture_orientations.py
+++ b/pydfnworks/pydfnworks/dfnGen/generation/output_report/plot_fracture_orientations.py
@@ -11,7 +11,8 @@ import math as m
 import mplstereonet
 import matplotlib.pyplot as plt
 import random
-from pydfnworks.general.logging import local_print_log 
+from pydfnworks.dfnGen.generation.orientations import normals_to_strike_dip
+from pydfnworks.general.logging import local_print_log
 
 def get_normal_vectors(fam, fractures):
     """
@@ -63,82 +64,6 @@ def get_normal_vectors(fam, fractures):
     for i, j in enumerate(fam["fracture list - final"]):
         normal_vectors[i, :] = fractures[j]["normal"]
     return normal_vectors
-
-def normalise_normals_to_lower_hemisphere(normals):
-    """
-    Ensures that all normal vectors are in the lower hemisphere by flipping any
-    vector with a positive z-component.
-
-    This is useful for plotting poles or orientations on lower-hemisphere
-    stereonets, ensuring consistency in directional statistics.
-
-    Parameters
-    ----------
-    normals : array-like
-        A (N, 3) array of normal vectors. Each row is expected to be a 3D vector.
-
-    Returns
-    -------
-    np.ndarray
-        A (N, 3) array of normal vectors, all adjusted to point into the lower hemisphere
-        (i.e., z-component ≤ 0).
-    """ 
-    normals = np.asarray(normals, float)
-    # Assuming z is "up". Flip any normal with positive z
-    flip = normals[:, 2] > 0
-    normals[flip] *= -1.0
-    return normals
-
-# ---------- Geometry helpers ----------
-def normals_to_strike_dip(normals):
-    """
-    Convert plane normals to strike and dip (right-hand rule).
-
-    Parameters
-    ----------
-    normals : (N, 3) array-like
-        Normal vectors (nx, ny, nz) in a right-handed ENU system
-        (x=East, y=North, z=Up). Need not be normalized.
-
-    Returns
-    -------
-    strikes : (N,) ndarray
-        Strike azimuths in degrees, clockwise from North, 0–360.
-    dips : (N,) ndarray
-        Dip angles from horizontal in degrees, 0–90.
-    dip_dirs : (N,) ndarray
-        Dip directions (azimuth of down-dip line) in degrees, 0–360.
-    """
-    normals = normalise_normals_to_lower_hemisphere(normals)
-
-    n = np.asarray(normals, dtype=float)
-    if n.ndim == 1:
-        n = n[np.newaxis, :]
-
-    # Normalize
-    n /= np.linalg.norm(n, axis=1)[:, np.newaxis]
-
-    nx = n[:, 0]
-    ny = n[:, 1]
-    nz = n[:, 2]
-
-    # Dip: angle between plane and horizontal
-    dip = np.degrees(np.arctan2(np.sqrt(nx**2 + ny**2), np.abs(nz)))
-
-    # Dip direction: opposite horizontal projection of normal
-    # Using atan2(East, North) to get azimuth clockwise from North
-    dx = -nx
-    dy = -ny
-    dip_dir = np.degrees(np.arctan2(dx, dy)) % 360.0
-
-    # Strike: 90° CCW from dip direction (right-hand rule)
-    strike = (dip_dir - 90.0) % 360.0
-    # convert type 
-    strike = np.asarray(strike, float)
-    dip = np.asarray(dip, float)
-    dip_dir = np.asarray(dip_dir, float)
-
-    return strike, dip, dip_dir
 
 
 def plot_rose_diagram(ax, strikes_deg, color):

--- a/pydfnworks/pydfnworks/dfnGen/generation/process_generator_output.py
+++ b/pydfnworks/pydfnworks/dfnGen/generation/process_generator_output.py
@@ -114,6 +114,8 @@ def gather_dfn_gen_output(self):
     self.surface_area = np.genfromtxt('dfnGen_output/surface_area_Final.dat', skip_header=1)
     ## load normal vectors
     self.normal_vectors = np.genfromtxt('dfnGen_output/normal_vectors.dat')
+    ## strike / dip of the fracture planes and trend / plunge of their poles
+    self.get_fracture_orientations()
     # Get fracture centers
     centers = []
     with open('dfnGen_output/translations.dat', "r") as fp:

--- a/pydfnworks/pydfnworks/general/dfnworks.py
+++ b/pydfnworks/pydfnworks/general/dfnworks.py
@@ -80,6 +80,7 @@ class DFNWORKS():
     from pydfnworks.dfnGen.generation.hydraulic.io import dump_hydraulic_values, dump_aperture, dump_perm, dump_transmissivity, dump_fracture_info
 
     from pydfnworks.dfnGen.generation.stress import stress_based_apertures
+    from pydfnworks.dfnGen.generation.orientations import get_fracture_orientations
     from pydfnworks.dfnGen.generation.input_checking.parameter_dictionaries import load_parameters
     from pydfnworks.dfnGen.generation.input_checking.fracture_family import add_fracture_family, print_family_information
     from pydfnworks.dfnGen.generation.input_checking.add_fracture_family_to_params import write_fracture_families, reorder_fracture_families


### PR DESCRIPTION
Closes #121

## Summary
Fracture orientation was only computed inside the output-report plotting code,
so it was not reachable for analysis. The DFN object now carries it directly,
computed automatically once the normals are loaded in `gather_dfn_gen_output()`:

| attribute | meaning | range |
|---|---|---|
| `DFN.strike` | strike azimuth of the fracture plane | 0–360° |
| `DFN.dip` | dip below horizontal | 0–90° |
| `DFN.dip_direction` | azimuth of the down-dip line | 0–360° |
| `DFN.trend` | trend of the pole (normal) | 0–360° |
| `DFN.plunge` | plunge of the pole (normal) | 0–90° |

Right-handed ENU convention (x=East, y=North, z=Up), lower hemisphere, which is
standard for stereonet work. `DFN.get_fracture_orientations()` can also be
called directly.

## Single implementation
The conversions now live in `dfnGen/generation/orientations.py`.
`plot_fracture_orientations.py` imports `normals_to_strike_dip` from there
instead of defining its own copy, so the report and the DFN attributes cannot
drift apart.

## Bug fixed along the way
The lower-hemisphere conversion mutated its input. It did
`np.asarray(normals, float)`, which returns the *caller's* array unchanged for a
float64 input, and then flipped rows of it in place. This was harmless where it
was previously called, but passing `DFN.normal_vectors` would have permanently
negated the stored normals. The canonical version copies.

## Verification
Textbook cases:

| plane | result |
|---|---|
| horizontal | dip 0°, pole plunge 90° |
| vertical, normal East | dip 90°, strike 180° (N–S), pole trend 90°, plunge 0° |
| vertical, normal North | dip 90°, strike 90° (E–W), pole trend 0° |
| 45° dipping east | dip 45°, dip direction 90°, strike 0°, pole trend 270° |

Identities verified over 500 random normals: `plunge == 90 - dip`,
`trend == (dip_direction + 180) % 360`, `strike == (dip_direction - 90) % 360`,
and all values in range. Confirmed the input normals are not modified, that a
full `create_network()` run populates all five attributes correctly, and that
the output report still imports and resolves to the shared implementation.