### PR TITLE
feat(dfnGraph): finite matrix-diffusion TDRW models (Dentz slab, annulus, Roubinet, from-file) — v2.12

### DIFF
--- a/examples/finite_matrix_diffusion/README.md
+++ b/examples/finite_matrix_diffusion/README.md
@@ -1,0 +1,38 @@
+# Finite matrix diffusion demonstration (Forsmark FFM01)
+
+Demonstrates the finite matrix-diffusion TDRW models on a Forsmark-like
+fracture network, focusing on the two controlling parameters: fracture
+spacing and matrix diffusivity.
+
+Three timescales position every feature of the breakthrough curves
+(with half-aperture b_f ~ 2e-5 m and t_peak ~ 1e8 s for this network):
+
+- departure from advective:  t* ~ (b_f/phi_m)^2 / D_m
+- finite-block cutoff:       tau_D = (spacing/2)^2 / D_m
+- equilibrium retardation:   R = 1 + phi_m * (spacing/2) / b_f
+
+`forsmark_percolation_comparison.py` generates the network, solves graph
+flow (Doolaeghe conductance), and runs a 12-case transport matrix at
+1e5 particles:
+
+1. **Spacing sweep** (D = 1e-13 m^2/s; spacings 0.1, 0.5, 2, 10 m):
+   cutoffs march to later times with spacing; the 10 m curve overlays
+   the infinite-matrix reference, demonstrating convergence to the
+   semi-infinite limit.
+2. **Diffusivity sweep** (spacing = 1 m; D = 1e-15, 1e-13, 1e-11):
+   departure and cutoff slide together; all finite curves approach the
+   same D-independent retardation shift R = 251.
+3. **Site-tied spacings** (1/P32 and 1/dQ from `compute_dQ`, D = 1e-13):
+   both overlay the infinite curve -- block-size effects are invisible
+   at Forsmark intensity over this observation window.
+
+Each run writes its parameters and predicted feature locations
+(tau_D, tau_D/t_peak, R) to `fmd_run_matrix.csv`. After the driver
+completes, generate the three figures with:
+
+    python plot_fmd_demo.py forsmark_pc_1_seed101
+
+The transport log reports the adaptive release position chosen for each
+dentz run (`--> Dentz release position eps = ...`); it caps at 1e-4 for
+small blocks and shrinks for large ones so the TDRW artifact timescale
+(eps * spacing/2)^2 / D_m stays below the earliest arrivals.

--- a/examples/finite_matrix_diffusion/forsmark_percolation_comparison.py
+++ b/examples/finite_matrix_diffusion/forsmark_percolation_comparison.py
@@ -1,0 +1,188 @@
+"""
+Forsmark FFM01 fracture network: calibrated versus inflated intensity.
+
+Generates two DFN realizations over the same 1000 m cubic domain that differ
+ONLY in the areal fracture intensity P32 of the three sets. Set orientations,
+Fisher concentrations, size exponents, radius range, transmissivity model,
+domain, and random seed are identical between the two cases, so any visual or
+transport difference is attributable to the intensity alone.
+
+  follin : calibrated site intensities, near-critical  (p_c = 1.00)
+  snl    : SNL (2016) reference-case intensities       (p_c = 3.31)
+
+Set SCENARIO below and run.  VISUAL_MODE = True produces a coarse mesh
+suitable for rendering rather than a flow-quality mesh.
+"""
+
+from pydfnworks import DFNWORKS
+import os
+
+# ----------------------------------------------------------------------
+SCENARIO    = "pc_1"      # "follin" or "snl"
+SEED        = 101           # same seed for both cases
+VISUAL_MODE = True          # True -> coarse mesh for visualization only
+NCPU        = 8
+# ----------------------------------------------------------------------
+
+# Areal fracture intensity P32 over the operational radius range [15, 500] m.
+# Values from the percolation analysis; the calibrated column is the Follin
+# hydrogeological DFN, the SNL column is the reference-case parameterization.
+#
+#   set     P32 follin     P32 snl      inflation
+#   NS       0.00591       0.03682        6.2x
+#   EW       0.00480       0.02769        5.8x
+#   HZ       0.02181       0.04597        2.1x
+#
+# NOTE: the dfnBoard case files use 5.96e-3 / 4.81e-3 / 2.23e-2, which differ
+# from these in the third significant figure. The values here are the ones the
+# percolation analysis was computed from.
+
+P32 = {
+    "pc_1": {"NS": 5.91000e-03, "EW": 4.80000e-03, "HZ": 2.18100e-02},
+    "pc_2": {"NS": 1.18200e-02, "EW": 9.60000e-03, "HZ": 4.36200e-02},
+    "pc_3": {"NS": 1.77300e-02, "EW": 1.44000e-02, "HZ": 6.54300e-02},
+}
+
+
+# Shared set geometry. Trend and plunge define the mean fracture POLE.
+#   NS  pole 090/00 -> vertical, striking N-S
+#   EW  pole 180/00 -> vertical, striking E-W
+#   HZ  pole 360/90 -> sub-horizontal
+SETS = [
+    # name, alpha, trend, plunge, kappa
+    ("NS", 2.50,  90.0,  0.0, 22.0),
+    ("EW", 2.70, 180.0,  0.0, 22.0),
+    ("HZ", 2.40, 360.0, 90.0, 10.0),
+]
+
+# Follin's calibrated values for the HZ set are kappa = 8 and alpha = 2.38.
+# The values above follow the SNL convention so that the two cases differ in
+# P32 alone. To run the fully calibrated variant, use ("HZ", 2.38, 360.0, 90.0, 8.0).
+
+R_MIN, R_MAX = 15.0, 500.0          # operational radius range, m
+HY_ALPHA, HY_BETA = 1.6e-9, 0.8     # transmissivity: T = alpha * r^beta
+
+assert SCENARIO in P32, f"SCENARIO must be one of {list(P32)}"
+jobname = os.path.join(os.getcwd(), f"forsmark_{SCENARIO}_seed101")
+
+DFN = DFNWORKS(jobname=jobname, ncpu=NCPU)
+
+DFN.params['domainSize']['value']            = [1000.0, 1000.0, 1000.0]
+DFN.params['domainSizeIncrease']['value']    = [100.0, 100.0, 100.0]
+DFN.params['h']['value']                     = 1.0
+DFN.params['boundaryFaces']['value']         = [1, 1, 0, 0, 0, 0]   # flow in x
+DFN.params['keepOnlyLargestCluster']['value'] = True
+DFN.params['ignoreBoundaryFaces']['value']   = False
+DFN.params['orientationOption']['value']     = 1                    # trend / plunge
+DFN.params['seed']['value']                  = SEED
+DFN.params['visualizationMode']['value']     = VISUAL_MODE
+
+for name, alpha, trend, plunge, kappa in SETS:
+    DFN.add_fracture_family(
+        shape="ell",
+        distribution="tpl",
+        alpha=alpha,
+        min_radius=R_MIN,
+        max_radius=R_MAX,
+        kappa=kappa,
+        trend=trend,
+        plunge=plunge,
+        aspect=1,
+        p32=P32[SCENARIO][name],
+        number_of_points=8,
+        hy_variable="transmissivity",
+        hy_function="correlated",
+        hy_params={"alpha": HY_ALPHA, "beta": HY_BETA},
+    )
+
+DFN.make_working_directory(delete=True)
+DFN.check_input()
+DFN.create_network()
+# DFN.output_report()                       # stereonets, rose diagrams, radii, FRAM
+# DFN.mesh_network()
+
+print(f"\n{SCENARIO}: {DFN.num_frac} fractures retained in the connected network")
+
+pressure_in = 1.1* 10**6
+pressure_out = 10**6
+G = DFN.run_graph_flow("left", "right",   
+                       pressure_in, pressure_out, conductance_model = "doolaeghe")
+
+p32, dQ, _ = DFN.compute_dQ(G)
+
+nparticles = 10**5     # 1e5 for tails resolved to PDF ~1e-7
+
+# ----------------------------------------------------------------------
+# Finite matrix diffusion demonstration matrix
+# ----------------------------------------------------------------------
+# Three timescales position every feature (b_f ~ 2e-5 m, t_peak ~ 1e8 s):
+#   departure from advective : t* ~ (b_f/phi)^2 / D = 4e-6 / D
+#   finite-block cutoff      : tau_D = (spacing/2)^2 / D
+#   equilibrium retardation  : R = 1 + phi*(spacing/2)/b_f ~ 1 + 250*spacing
+#
+# Config 1  spacing sweep at D = 1e-13: cutoffs at ~2.5e2, 6e3, 1e5,
+#           off-window t_peak; the 10 m curve should overlay the infinite
+#           reference (convergence to the infinite-matrix limit).
+# Config 2  diffusivity sweep at spacing = 1 m: departure and cutoff slide
+#           together; all three approach the same R = 251 equilibrium shift.
+# Config 3  site-tied spacings 1/P32 and 1/dQ (network values from
+#           compute_dQ) at D = 1e-13: expected to overlay infinite
+#           (block-size effects invisible at Forsmark intensity over
+#           this window).
+
+import csv
+
+D_REF = 1e-13
+D_SWEEP = [1e-15, 1e-13, 1e-11]
+SPACING_SWEEP = [0.1, 0.5, 2.0, 10.0]          # config 1
+SPACING_P32 = 1.0 / p32                            # config 3 (compute_dQ)
+SPACING_DQ = 1.0 / dQ                              # config 3 (compute_dQ)
+
+PHI_M = 0.01
+B_F_NOMINAL = 2e-5     # half-aperture from T = 1.6e-9 r^0.8 + cubic law
+T_PEAK_NOMINAL = 1e8   # s, for the predicted-feature columns only
+
+runs = []
+for D in D_SWEEP:                                  # infinite references
+    runs.append(("infinite", D, None, ""))
+for spacing in SPACING_SWEEP:                      # config 1
+    runs.append(("dentz", D_REF, spacing, ""))
+for D in D_SWEEP:                                  # config 2
+    runs.append(("dentz", D, 1.0, ""))
+runs.append(("dentz", D_REF, SPACING_P32, "1/P32"))   # config 3
+runs.append(("dentz", D_REF, SPACING_DQ, "1/dQ"))     # config 3
+
+with open("fmd_run_matrix.csv", "w", newline="") as f:
+    writer = csv.writer(f)
+    writer.writerow(["partime_file", "model", "matrix_diffusivity",
+                     "fracture_spacing", "label", "tau_D_s",
+                     "tau_D_over_tpeak", "retardation_R"])
+    for model, D, spacing, label in runs:
+        if model == "infinite":
+            name = f"graph_partime_infinite_D{D:.0e}"
+            writer.writerow([name, model, D, "", label, "", "", ""])
+        else:
+            name = f"graph_partime_dentz_D{D:.0e}_s{spacing:0.2f}"
+            tau_D = (spacing / 2)**2 / D
+            R = 1 + PHI_M * (spacing / 2) / B_F_NOMINAL
+            writer.writerow([name, model, D, spacing, label,
+                             f"{tau_D:.3e}",
+                             f"{tau_D / T_PEAK_NOMINAL:.2e}", f"{R:.0f}"])
+
+for model, D, spacing, label in runs:
+    if model == "infinite":
+        name = f"graph_partime_infinite_D{D:.0e}"
+    else:
+        name = f"graph_partime_dentz_D{D:.0e}_s{spacing:0.2f}"
+    print(f"\n=== {name} ===")
+    DFN.run_graph_transport(G, nparticles,
+                            partime_file=name,
+                            frac_id_file=None,
+                            format="hdf5",
+                            initial_positions="flux",
+                            dump_traj=False,
+                            tdrw_flag=True,
+                            tdrw_model=model,
+                            matrix_porosity=PHI_M,
+                            matrix_diffusivity=D,
+                            fracture_spacing=spacing)

--- a/examples/finite_matrix_diffusion/plot_fmd_demo.py
+++ b/examples/finite_matrix_diffusion/plot_fmd_demo.py
@@ -1,0 +1,101 @@
+"""
+plot_fmd_demo.py
+----------------
+Three demonstration figures from the finite-matrix-diffusion run matrix
+produced by forsmark_percolation_comparison.py:
+
+  fig 1  spacing sweep at D = 1e-13 (cutoffs march right; 10 m overlays infinite)
+  fig 2  diffusivity sweep at spacing = 1 m (paired infinite refs, dashed)
+  fig 3  site-tied spacing = 1/P32_total vs infinite (expected overlay)
+
+Usage:  python plot_fmd_demo.py forsmark_pc_1_seed101
+"""
+import sys
+import numpy as np
+import h5py
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+YEAR = np.pi * 1e7
+D_REF = 1e-13
+SPACING_SWEEP = [0.1, 0.5, 2.0, 10.0]
+D_SWEEP = [1e-15, 1e-13, 1e-11]
+
+dirname = sys.argv[1] if len(sys.argv) > 1 else "forsmark_pc_1_seed101"
+matrix = pd.read_csv(f"{dirname}/fmd_run_matrix.csv")
+site_rows = matrix[matrix.label.notna() & (matrix.label != "")]
+
+
+def load_times(name, column="Total travel time [s]"):
+    with h5py.File(f"{dirname}/{name}.hdf5", "r") as f5:
+        return np.asarray(f5[column][:]) / YEAR
+
+
+def log_pdf(t, num_bins=100):
+    bins = np.logspace(np.log10(t.min()), np.log10(t.max()), num_bins + 1)
+    counts, edges = np.histogram(t, bins=bins, density=True)
+    return np.sqrt(edges[:-1] * edges[1:]), counts
+
+
+def base_axes(title):
+    fig, ax = plt.subplots(figsize=(10, 8))
+    t_adv = load_times(f"graph_partime_infinite_D{D_REF:.0e}",
+                       "Advective time [s]")
+    tc, pdf = log_pdf(t_adv)
+    t_peak = tc[np.argmax(pdf)]
+    ax.loglog(tc / t_peak, pdf, color="0.4", lw=2, label="Advective")
+    ax.set_xlabel(r"Normalized Time [t / $t_{peak}$]", fontsize=18)
+    ax.set_ylabel("PDF [-]", fontsize=18)
+    ax.tick_params(axis="both", which="major", labelsize=14)
+    ax.grid(True, which="both", alpha=0.3)
+    ax.set_title(title, fontsize=14)
+    return fig, ax, t_peak
+
+
+def add_curve(ax, name, t_peak, label, **kw):
+    tc, pdf = log_pdf(load_times(name))
+    ax.loglog(tc / t_peak, pdf, label=label, **kw)
+
+
+# --- fig 1: spacing sweep at D_REF -----------------------------------
+fig, ax, t_peak = base_axes(
+    rf"Spacing sweep, $D_m = {D_REF:.0e}$ m$^2$/s, $\phi_m = 0.01$")
+add_curve(ax, f"graph_partime_infinite_D{D_REF:.0e}", t_peak,
+          "Infinite matrix", color="k", lw=2.5)
+for spacing, c in zip(SPACING_SWEEP, plt.cm.viridis(np.linspace(0, 0.85, 4))):
+    row = matrix[(matrix.model == "dentz")
+                 & (matrix.fracture_spacing == spacing)
+                 & (np.isclose(matrix.matrix_diffusivity, D_REF))].iloc[0]
+    add_curve(ax, row.partime_file, t_peak,
+              rf"FMD {spacing:g} m  ($\tau_D = {row.tau_D_over_tpeak:.0e}\,t_p$, R={row.retardation_R:.0f})",
+              color=c, lw=2)
+ax.legend(fontsize=13)
+plt.tight_layout(); plt.savefig("fmd_fig1_spacing_sweep.png", dpi=150)
+
+# --- fig 2: diffusivity sweep at spacing = 1 m -----------------------
+fig, ax, t_peak = base_axes(
+    r"Diffusivity sweep, spacing = 1 m  (dashed: matching infinite)")
+for D, c in zip(D_SWEEP, ["tab:blue", "tab:green", "tab:red"]):
+    add_curve(ax, f"graph_partime_infinite_D{D:.0e}", t_peak,
+              rf"Inf., $D={D:.0e}$", color=c, lw=1.5, ls="--")
+    add_curve(ax, f"graph_partime_dentz_D{D:.0e}_s1.00", t_peak,
+              rf"FMD 1 m, $D={D:.0e}$", color=c, lw=2)
+ax.legend(fontsize=13)
+plt.tight_layout(); plt.savefig("fmd_fig2_diffusivity_sweep.png", dpi=150)
+
+# --- fig 3: site-tied spacings (1/P32 and 1/dQ) ----------------------
+fig, ax, t_peak = base_axes(
+    rf"Site-tied spacings, $D_m = {D_REF:.0e}$ m$^2$/s")
+add_curve(ax, f"graph_partime_infinite_D{D_REF:.0e}", t_peak,
+          "Infinite matrix", color="k", lw=2.5)
+for (_, row), c in zip(site_rows.iterrows(), ["tab:orange", "tab:purple"]):
+    spacing = float(row.fracture_spacing)
+    add_curve(ax, row.partime_file, t_peak,
+              rf"FMD {row.label} = {spacing:.1f} m", color=c, lw=2)
+ax.legend(fontsize=13)
+plt.tight_layout(); plt.savefig("fmd_fig3_site_spacing.png", dpi=150)
+
+print("saved fmd_fig1_spacing_sweep.png, fmd_fig2_diffusivity_sweep.png, "
+      "fmd_fig3_site_spacing.png")

--- a/pydfnworks/pydfnworks/__init__.py
+++ b/pydfnworks/pydfnworks/__init__.py
@@ -48,7 +48,7 @@ __bibtex__ = """@article{hyman2015dfnworks,
 }
 """
 
-__version__ = "2.10.1"
+__version__ = "2.12"
 
 __release_date__ = "30-06-2026"
 

--- a/pydfnworks/pydfnworks/__init__.py
+++ b/pydfnworks/pydfnworks/__init__.py
@@ -50,7 +50,7 @@ __bibtex__ = """@article{hyman2015dfnworks,
 
 __version__ = "2.12"
 
-__release_date__ = "30-06-2026"
+__release_date__ = "20-08-2026"
 
 from ._install_info import get_install_date
 __install_date__ = get_install_date()

--- a/pydfnworks/pydfnworks/dfnGraph/attributes/perm_area.py
+++ b/pydfnworks/pydfnworks/dfnGraph/attributes/perm_area.py
@@ -2,6 +2,8 @@ import numpy as np
 import networkx as nx
 import sys
 
+from pydfnworks.general.logging import local_print_log
+
 
 
 def add_perm(G):

--- a/pydfnworks/pydfnworks/dfnGraph/flow/graph_flow.py
+++ b/pydfnworks/pydfnworks/dfnGraph/flow/graph_flow.py
@@ -57,7 +57,7 @@ def get_laplacian_sparse_mat(G,
 
 
 def prepare_graph_with_attributes(inflow, outflow, G=None,
-                                  conductance_model="karra", diameter=None,
+                                  conductance_model="doolaeghe", diameter=None,
                                   simplify=False, normal_vectors=None,
                                   **conductance_kwargs):
     """ Create a NetworkX graph, prepare it for flow solve by equipping edges with  attributes, renumber vertices, and tag vertices which are on inlet or outlet
@@ -274,7 +274,7 @@ def run_graph_flow(self,
                    phi=1,
                    G=None,
                    graph_flow_name = "graph_flow.hdf5",
-                   conductance_model="karra",
+                   conductance_model="doolaeghe",
                    diameter_from="area",
                    simplify=False,
                    **conductance_kwargs):
@@ -306,7 +306,7 @@ def run_graph_flow(self,
         G : Input Graph
 
         conductance_model : string
-            edge conductance model, 'karra' (default) or 'doolaeghe'. See
+            edge conductance model, 'doolaeghe' (default) or 'karra'. See
             pydfnworks.dfnGraph.attributes.conductance.
 
         diameter_from : string

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -262,8 +262,9 @@ def run_graph_transport(self,
             Matrix Diffusivity used in TDRW (SI units m^2/s)
 
         fracture_spacing : float
-            finite block size for limited matrix diffusion. Required for all
-            finite tdrw models
+            distance between adjacent parallel fractures [m]; the matrix
+            block half-width is fracture_spacing/2. Required for all finite
+            tdrw models
 
         tdrw_filename : string
             path to a two-column ASCII file (return times, CDF). Required
@@ -304,9 +305,9 @@ def run_graph_transport(self,
         # size model by providing fracture_spacing without naming a model.
         if tdrw_model == 'infinite' and fracture_spacing is not None:
             self.print_log(
-                "--> fracture_spacing provided without a finite tdrw_model. Using 'roubinet' (previous default for limited matrix diffusion).",
+                "--> fracture_spacing provided without a finite tdrw_model. Using 'dentz' (default finite matrix diffusion model; pass tdrw_model='roubinet' for the pre-2.11 limited model).",
                 'warning')
-            tdrw_model = 'roubinet'
+            tdrw_model = 'dentz'
         check_tdrw_params(matrix_porosity, matrix_diffusivity,
                           fracture_spacing, tdrw_model, tdrw_filename)
 

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -51,7 +51,8 @@ def track_particle(data, verbose=False):
                         data["tdrw_flag"], data["tdrw_model"],
                         data["matrix_porosity"], data["matrix_diffusivity"],
                         data["fracture_spacing"], data["trans_prob"],
-                        data["transfer_time"], data["cp_flag"],
+                        data["transfer_time"], data["release_eps"],
+                        data["cp_flag"],
                         data["control_planes"], data["direction"],
                         data["seed"])
 
@@ -340,7 +341,7 @@ def run_graph_transport(self,
     if tdrw_flag and tdrw_model in FINITE_MODELS:
         self.print_log(f"--> Using limited matrix block size for TDRW")
         self.print_log(f"--> Fracture spacing {fracture_spacing:0.2e} [m]")
-        transfer_time, trans_prob = set_up_limited_matrix_diffusion(
+        transfer_time, trans_prob, release_eps = set_up_limited_matrix_diffusion(
             G,
             tdrw_model,
             fracture_spacing,
@@ -350,6 +351,7 @@ def run_graph_transport(self,
     else:
         trans_prob = None
         transfer_time = None
+        release_eps = None
     ## main loop
     if self.ncpu == 1:
         tic = timeit.default_timer()
@@ -360,6 +362,7 @@ def run_graph_transport(self,
             particle = Particle(i, ip[i], tdrw_flag, tdrw_model,
                                 matrix_porosity, matrix_diffusivity,
                                 fracture_spacing, trans_prob, transfer_time,
+                                release_eps,
                                 control_plane_flag, control_planes, direction,
                                 seed)
             particle.track(G, nbrs_dict)
@@ -416,6 +419,7 @@ def run_graph_transport(self,
             data["fracture_spacing"] = fracture_spacing
             data["transfer_time"] = transfer_time
             data["trans_prob"] = trans_prob
+            data["release_eps"] = release_eps
             data["cp_flag"] = control_plane_flag
             data["control_planes"] = control_planes
             data["direction"] = direction

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -305,7 +305,7 @@ def run_graph_transport(self,
         # size model by providing fracture_spacing without naming a model.
         if tdrw_model == 'infinite' and fracture_spacing is not None:
             self.print_log(
-                "--> fracture_spacing provided without a finite tdrw_model. Using 'dentz' (default finite matrix diffusion model; pass tdrw_model='roubinet' for the pre-2.11 limited model).",
+                "--> fracture_spacing provided without a finite tdrw_model. Using 'dentz' (default finite matrix diffusion model; pass tdrw_model='roubinet' for the pre-2.12 limited model).",
                 'warning')
             tdrw_model = 'dentz'
         check_tdrw_params(matrix_porosity, matrix_diffusivity,

--- a/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/graph_transport.py
@@ -13,7 +13,7 @@ import multiprocessing as mp
 
 # pydfnworks graph modules modules
 import pydfnworks.dfnGraph.transport.io as io
-from pydfnworks.dfnGraph.transport.tdrw import set_up_limited_matrix_diffusion
+from pydfnworks.dfnGraph.transport.tdrw import check_tdrw_params, set_up_limited_matrix_diffusion, FINITE_MODELS
 from pydfnworks.dfnGraph.transport.particle import Particle
 from pydfnworks.general.logging import local_print_log
 
@@ -48,11 +48,12 @@ def track_particle(data, verbose=False):
         )
 
     particle = Particle(data["particle_number"], data["initial_position"],
-                        data["tdrw_flag"], data["matrix_porosity"],
-                        data["matrix_diffusivity"], data["fracture_spacing"],
-                        data["trans_prob"], data["transfer_time"],
-                        data["cp_flag"], data["control_planes"],
-                        data["direction"], data["seed"])
+                        data["tdrw_flag"], data["tdrw_model"],
+                        data["matrix_porosity"], data["matrix_diffusivity"],
+                        data["fracture_spacing"], data["trans_prob"],
+                        data["transfer_time"], data["cp_flag"],
+                        data["control_planes"], data["direction"],
+                        data["seed"])
 
     # # get current process information
     global nbrs_dict
@@ -183,42 +184,6 @@ def create_neighbor_list(G):
     return nbrs_dict
 
 
-def check_tdrw_params(matrix_porosity, matrix_diffusivity, fracture_spacing):
-    """ Check that the provided tdrw values are physiscal
-
-
-    Parameters
-    ----------
-        G: NetworkX graph 
-            Directed Graph obtained from output of graph_flow
-
-    Returns
-    -------
-        dict : nested dictionary.
-
-    Notes
-    -----
-        dict[n]['child'] is a list of vertices downstream to vertex n
-        dict[n]['prob'] is a list of probabilities for choosing a downstream node for vertex n
-    
-    """
-
-    if matrix_porosity is None:
-        error = f"Error. Requested TDRW but no value for matrix_porosity was provided\n"
-        local_print_log(error, 'error')
-    elif matrix_porosity < 0 or matrix_porosity > 1:
-        error = f"Error. Requested TDRW but value for matrix_porosity provided is outside of [0,1]. Value provided {matrix_porosity}\n"
-        local_print_log(error, 'error')
-    if matrix_diffusivity is None:
-        error = f"Error. Requested TDRW but no value for matrix_diffusivity was provided\n"
-        local_print_log(error, 'error')
-
-    if fracture_spacing is not None:
-        if fracture_spacing <= 0:
-            error = f"Error. Non-positive value for fracture_spacing was provided.\nValue {fracture_spacing}\nExiting program"
-            local_print_log(error, 'error')
-
-
 def check_control_planes(control_planes, direction):
     control_plane_flag = False
     if not type(control_planes) is list:
@@ -249,9 +214,11 @@ def run_graph_transport(self,
                         initial_positions="uniform",
                         dump_traj=False,
                         tdrw_flag=False,
+                        tdrw_model='infinite',
                         matrix_porosity=None,
                         matrix_diffusivity=None,
                         fracture_spacing=None,
+                        tdrw_filename=None,
                         control_planes=None,
                         direction=None,
                         cp_filename='control_planes'):
@@ -283,14 +250,24 @@ def run_graph_transport(self,
         tdrw_flag : Bool
             if False, matrix_porosity and matrix_diffusivity are ignored
 
+        tdrw_model : string
+            Matrix diffusion model. Options: 'infinite' (default, unlimited
+            block size), 'roubinet', 'dentz', 'annulus' (finite block size),
+            or 'from_file' (return-time CDF read from tdrw_filename).
+
         matrix_porosity: float
             Matrix Porosity used in TDRW
 
         matrix_diffusivity: float
             Matrix Diffusivity used in TDRW (SI units m^2/s)
 
-        fracture_spaceing : float
-            finite block size for limited matrix diffusion
+        fracture_spacing : float
+            finite block size for limited matrix diffusion. Required for all
+            finite tdrw models
+
+        tdrw_filename : string
+            path to a two-column ASCII file (return times, CDF). Required
+            when tdrw_model is 'from_file'
 
         control_planes : list of floats
             list of control plane locations to dump travel times. Only in primary direction of flow. 
@@ -323,11 +300,15 @@ def run_graph_transport(self,
     
     # Check parameters for TDRW
     if tdrw_flag:
+        # Backward compatibility: older callers requested the limited block
+        # size model by providing fracture_spacing without naming a model.
+        if tdrw_model == 'infinite' and fracture_spacing is not None:
+            self.print_log(
+                "--> fracture_spacing provided without a finite tdrw_model. Using 'roubinet' (previous default for limited matrix diffusion).",
+                'warning')
+            tdrw_model = 'roubinet'
         check_tdrw_params(matrix_porosity, matrix_diffusivity,
-                          fracture_spacing)
-        self.print_log(
-            f"--> Running particle transport with TDRW.\n--> Matrix porosity {matrix_porosity}.\n--> Matrix Diffusivity {matrix_diffusivity} m^2/s"
-        )
+                          fracture_spacing, tdrw_model, tdrw_filename)
 
     if control_planes is None:
         control_plane_flag = False
@@ -355,15 +336,16 @@ def run_graph_transport(self,
     if dump_traj:
         self.print_log(f"--> Writing trajectory information to file")
 
-    if fracture_spacing is not None:
+    if tdrw_flag and tdrw_model in FINITE_MODELS:
         self.print_log(f"--> Using limited matrix block size for TDRW")
         self.print_log(f"--> Fracture spacing {fracture_spacing:0.2e} [m]")
-        trans_prob = set_up_limited_matrix_diffusion(G, fracture_spacing,
-                                                     matrix_porosity,
-                                                     matrix_diffusivity)
-        # This doesn't change for the system.
-        # Transfer time diffusing between fracture blocks
-        transfer_time = fracture_spacing**2 / (2 * matrix_diffusivity)
+        transfer_time, trans_prob = set_up_limited_matrix_diffusion(
+            G,
+            tdrw_model,
+            fracture_spacing,
+            matrix_porosity,
+            matrix_diffusivity,
+            tdrw_filename=tdrw_filename)
     else:
         trans_prob = None
         transfer_time = None
@@ -374,10 +356,11 @@ def run_graph_transport(self,
         for i in range(nparticles):
             if i % 1000 == 0:
                 self.print_log(f"--> Starting particle {i} out of {nparticles}")
-            particle = Particle(i, ip[i], tdrw_flag, matrix_porosity,
-                                matrix_diffusivity, fracture_spacing,
-                                trans_prob, transfer_time, control_plane_flag,
-                                control_planes, direction, seed)
+            particle = Particle(i, ip[i], tdrw_flag, tdrw_model,
+                                matrix_porosity, matrix_diffusivity,
+                                fracture_spacing, trans_prob, transfer_time,
+                                control_plane_flag, control_planes, direction,
+                                seed)
             particle.track(G, nbrs_dict)
             particles.append(particle)
 
@@ -407,15 +390,26 @@ def run_graph_transport(self,
         pool = mp.get_context("fork").Pool(min(self.ncpu, nparticles))
 
         particles = []
+        # log progress every 2.5% of completed particles
+        log_interval = max(1, int(nparticles * 0.025))
+        progress = {"completed": 0, "next_log": log_interval}
 
         def gather_output(output):
             particles.append(output)
+            progress["completed"] += 1
+            if progress["completed"] >= progress["next_log"]:
+                percentage = 100 * progress["completed"] / nparticles
+                self.print_log(
+                    f"--> Completed {progress['completed']} out of {nparticles} particles\t({percentage:0.2f}%)"
+                )
+                progress["next_log"] += log_interval
 
         for i in range(nparticles):
             data = {}
             data["particle_number"] = i
             data["initial_position"] = ip[i]
             data["tdrw_flag"] = tdrw_flag
+            data["tdrw_model"] = tdrw_model
             data["matrix_porosity"] = matrix_porosity
             data["matrix_diffusivity"] = matrix_diffusivity
             data["fracture_spacing"] = fracture_spacing

--- a/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
@@ -15,11 +15,16 @@ class Particle():
         * frac_seq : Dictionary, contains information about fractures through which the particle went
     '''
 
-    from pydfnworks.dfnGraph.transport.tdrw import unlimited_matrix_diffusion, limited_matrix_diffusion
+    from pydfnworks.dfnGraph.transport.tdrw.infinite import unlimited_matrix_diffusion
+    from pydfnworks.dfnGraph.transport.tdrw.roubinet import limited_matrix_diffusion_roubinet
+    from pydfnworks.dfnGraph.transport.tdrw.dentz import limited_matrix_diffusion_dentz
+    from pydfnworks.dfnGraph.transport.tdrw.annulus import limited_matrix_diffusion_annulus
+    from pydfnworks.dfnGraph.transport.tdrw.from_file import limited_matrix_diffusion_from_file
 
-    def __init__(self, particle_number, ip, tdrw_flag, matrix_porosity,
-                 matrix_diffusivity, fracture_spacing, trans_prob,
-                 transfer_time, cp_flag, control_planes, direction, seed=0):
+    def __init__(self, particle_number, ip, tdrw_flag, tdrw_model,
+                 matrix_porosity, matrix_diffusivity, fracture_spacing,
+                 trans_prob, transfer_time, cp_flag, control_planes,
+                 direction, seed=0):
         self.particle_number = particle_number
         # every particle gets its own independent random stream, derived from
         # the DFN seed so the whole ensemble is reproducible (see track())
@@ -42,6 +47,8 @@ class Particle():
         self.matrix_porosity = matrix_porosity
         self.matrix_diffusivity = matrix_diffusivity
         self.fracture_spacing = fracture_spacing
+        self.tdrw_model = tdrw_model
+        self.tau_D = None
         self.trans_prob = trans_prob
         self.transfer_time = transfer_time
         self.cp_flag = cp_flag
@@ -54,8 +61,12 @@ class Particle():
         self.cp_adv_time = []
         self.cp_tdrw_time = []
         self.cp_pathline_length = []
-        # self.cp_x1 = []
-        # self.cp_x2 = []
+
+        if tdrw_model in ("dentz", "annulus", "from_file"):
+            # Timescale rescaling dimensionless sampled return times to
+            # physical times. For the annulus model this is tau1 = r1^2 / D
+            # where r1 = fracture_spacing is the outer (reflecting) radius.
+            self.tau_D = self.fracture_spacing**2 / self.matrix_diffusivity
 
  
         self.velocity = []
@@ -200,7 +211,7 @@ class Particle():
                 self.cp_tdrw_time.append(tau)
 
             self.cp_index += 1
-            # if we're crossed all the control planes, turn off cp flag for this particle
+            # if we've crossed all the control planes, turn off cp flag for this particle
             if self.cp_index >= len(self.control_planes):
                 self.cp_flag = False
                 break
@@ -279,15 +290,24 @@ class Particle():
         while not self.exit_flag:
             self.advect(G, nbrs_dict)
             if self.exit_flag:
-                # self.update()
                 self.cleanup_frac_seq()
                 break
 
             if self.tdrw_flag:
-                if self.fracture_spacing is None:
+                if self.tdrw_model == "infinite":
                     self.unlimited_matrix_diffusion(G)
+                elif self.tdrw_model == "roubinet":
+                    self.limited_matrix_diffusion_roubinet(G)
+                elif self.tdrw_model == "dentz":
+                    self.limited_matrix_diffusion_dentz(G)
+                elif self.tdrw_model == "annulus":
+                    self.limited_matrix_diffusion_annulus(G)
+                elif self.tdrw_model == "from_file":
+                    self.limited_matrix_diffusion_from_file(G)
                 else:
-                    self.limited_matrix_diffusion(G)
+                    local_print_log(
+                        f"Error: Unknown TDRW model '{self.tdrw_model}' during tracking.",
+                        "error")
 
             if self.cp_flag:
                 self.cross_control_plane(G)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
@@ -64,9 +64,12 @@ class Particle():
 
         if tdrw_model in ("dentz", "annulus", "from_file"):
             # Timescale rescaling dimensionless sampled return times to
-            # physical times. For the annulus model this is tau1 = r1^2 / D
-            # where r1 = fracture_spacing is the outer (reflecting) radius.
-            self.tau_D = self.fracture_spacing**2 / self.matrix_diffusivity
+            # physical times: tau_D = B^2 / D with matrix half-width
+            # B = fracture_spacing / 2 (half the spacing between adjacent
+            # fractures, matching the roubinet model's convention). For the
+            # annulus model B is the outer (reflecting) radius r1.
+            half_width = self.fracture_spacing / 2
+            self.tau_D = half_width**2 / self.matrix_diffusivity
 
  
         self.velocity = []

--- a/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/particle.py
@@ -23,8 +23,8 @@ class Particle():
 
     def __init__(self, particle_number, ip, tdrw_flag, tdrw_model,
                  matrix_porosity, matrix_diffusivity, fracture_spacing,
-                 trans_prob, transfer_time, cp_flag, control_planes,
-                 direction, seed=0):
+                 trans_prob, transfer_time, release_eps, cp_flag,
+                 control_planes, direction, seed=0):
         self.particle_number = particle_number
         # every particle gets its own independent random stream, derived from
         # the DFN seed so the whole ensemble is reproducible (see track())
@@ -51,6 +51,7 @@ class Particle():
         self.tau_D = None
         self.trans_prob = trans_prob
         self.transfer_time = transfer_time
+        self.release_eps = release_eps
         self.cp_flag = cp_flag
         self.control_planes = control_planes
         self.cp_index = 0

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/__init__.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/__init__.py
@@ -1,0 +1,6 @@
+from pydfnworks.dfnGraph.transport.tdrw.setup import check_tdrw_params, set_up_limited_matrix_diffusion, FINITE_MODELS, VALID_MODELS
+from pydfnworks.dfnGraph.transport.tdrw.infinite import unlimited_matrix_diffusion, t_diff_unlimited
+from pydfnworks.dfnGraph.transport.tdrw.roubinet import limited_matrix_diffusion_roubinet
+from pydfnworks.dfnGraph.transport.tdrw.dentz import limited_matrix_diffusion_dentz
+from pydfnworks.dfnGraph.transport.tdrw.annulus import limited_matrix_diffusion_annulus
+from pydfnworks.dfnGraph.transport.tdrw.from_file import limited_matrix_diffusion_from_file

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
@@ -1,0 +1,148 @@
+"""
+.. module:: annulus.py
+   :synopsis: Finite matrix diffusion in a cylindrical annulus geometry.
+              Return times are sampled from the first-passage time CDF of
+              diffusion in an annular block, inverted from the Laplace
+              domain with the Stehfest algorithm.
+"""
+
+import numpy as np
+from scipy.special import ive, kve, iv, kv
+
+from pydfnworks.dfnGraph.transport.tdrw.stehfest import build_inverse_cdf_table
+from pydfnworks.dfnGraph.transport.tdrw.trapping import poisson_trapping_diffusion_time
+
+# Dimensionless release position (r' - r0)/r1 next to the absorbing wall.
+# The sampler's trapping rate and the inverse CDF table must use the same value.
+RELEASE_EPS = 1e-2
+
+
+def Psi_star_annulus(s, eps, tau0, tau1):
+    """ Laplace transform of the CDF for diffusion return time in a cylindrical annulus.
+
+    Geometry: cylindrical annulus with inner radius r0 (absorbing, fracture-matrix
+    interface) and outer radius r1 (reflecting, block interior).
+    Particle released at r' = r0*(1+eps), just inside the absorbing wall.
+
+    Parameters
+    ----------
+        s : np.ndarray
+            Laplace variable values.
+
+        eps : float
+            (r' - r0) / r1, dimensionless release position.
+
+        tau0 : float
+            r0^2 / D, inner-radius diffusion timescale.
+
+        tau1 : float
+            r1^2 / D, outer-radius diffusion timescale.
+
+    Notes
+    -----
+        Branch switch at |s*tau1| = 100, matching MATLAB cdfLaplace.m:
+        small branch: unscaled iv/kv (safe for |s*tau1| <= 100);
+        large branch: scaled ive/kve with exp prefactors (avoids overflow).
+
+        ive(n,x) = exp(-x)*In(x)  ->  MATLAB besseli(n,x,1)
+        kve(n,x) = exp(x) *Kn(x)  ->  MATLAB besselk(n,x,1)
+
+        The branch switch is essential for correct small-t behavior.
+        F_cdf(s) = F_psi(s) / s
+    """
+    q0 = np.sqrt(s * tau0)
+    q0_eps = (1.0 + eps) * q0
+    q1 = np.sqrt(s * tau1)
+
+    large = s * tau1 > 100
+
+    # large-argument branch
+    I0e_eps = ive(0, q0_eps)
+    K0e_eps = kve(0, q0_eps)
+    I0e_0 = ive(0, q0)
+    K0e_0 = kve(0, q0)
+    I1e_1 = ive(1, q1)
+    K1e_1 = kve(1, q1)
+
+    exp1 = np.exp(np.clip((2 + eps) * q0 - 2 * q1, -500, 500))
+    exp2 = np.exp(np.clip(-eps * q0, -500, 500))
+    expd = np.exp(np.clip(2 * q0 - 2 * q1, -500, 500))
+
+    num_large = exp1 * I0e_eps * K1e_1 + exp2 * K0e_eps * I1e_1
+    den_large = expd * I0e_0 * K1e_1 + K0e_0 * I1e_1
+
+    # small-argument branch
+    # errstate suppresses overflow warnings from elements that will be
+    # discarded by np.where (both branches are always evaluated)
+    with np.errstate(invalid='ignore', over='ignore'):
+        num_small = iv(0, q0_eps) * kv(1, q1) + kv(0, q0_eps) * iv(1, q1)
+        den_small = iv(0, q0) * kv(1, q1) + kv(0, q0) * iv(1, q1)
+
+    num = np.where(large, num_large, num_small)
+    den = np.where(large, den_large, den_small)
+
+    return num / (den * s)
+
+
+def Psi_pdf_star_annulus(s, eps, tau0, tau1):
+    """ Laplace transform of the first-passage time PDF: psi*(s) = s * F_cdf(s) """
+    return Psi_star_annulus(s, eps, tau0, tau1) * s
+
+
+def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, tau0=1e-4, tau1=1e3,
+                     stehfest_n=16):
+    """ Precompute the inverse CDF table for cylindrical annulus return-time sampling.
+
+    Parameters match Marco Dentz's InvLaplace.m defaults:
+    eps = 1e-2 dimensionless release position (r'-r0)/r1;
+    tau0 = 1e-4 inner-radius timescale r0^2/D;
+    tau1 = 1e3 outer-radius timescale r1^2/D.
+
+    The time range starts at 1e-10 to ensure Stehfest samples large enough s
+    for correct early-time behavior (requires s >> (1/eps)^2 / tau0).
+
+    Returns
+    -------
+        (times, cdf_vals) : tuple of np.ndarray
+            Inverse CDF lookup arrays for use with np.interp.
+    """
+    times = np.logspace(-10, 2, num_samples)
+    return build_inverse_cdf_table(Psi_star_annulus, times, stehfest_n=stehfest_n,
+                                   eps=eps, tau0=tau0, tau1=tau1)
+
+
+def limited_matrix_diffusion_annulus(self, G):
+    """ Matrix diffusion with finite cylindrical annular block geometry
+
+    Parameters
+    ----------
+        G : NetworkX graph
+            graph obtained from graph_flow
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        Samples diffusion return times from a finite cylindrical annular
+        matrix block. The inner radius r0 is the absorbing fracture-matrix
+        interface; the outer radius r1 is the reflecting block interior.
+        A particle is released at r' = r0*(1 + eps), just inside the
+        absorbing wall.
+
+        The Laplace-domain solution uses modified Bessel functions I0, I1,
+        K0, K1. Two numerical branches are used matching MATLAB cdfLaplace.m:
+        unscaled Bessels for |s*tau1| <= 100, and scaled Bessels (ive, kve)
+        with explicit exponential prefactors for |s*tau1| > 100.
+
+        tau1 = r1^2 / D is stored on the particle as self.tau_D and used
+        to rescale dimensionless sampled return times to physical times [s].
+
+        The inverse CDF table (self.transfer_time, self.trans_prob) must
+        be precomputed via make_inverse_cdf and attached to the particle
+        before transport begins.
+
+        All other parameters are attached to the particle class.
+    """
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
@@ -12,8 +12,9 @@ from scipy.special import ive, kve, iv, kv
 from pydfnworks.dfnGraph.transport.tdrw.stehfest import build_inverse_cdf_table
 from pydfnworks.dfnGraph.transport.tdrw.trapping import poisson_trapping_diffusion_time
 
-# Dimensionless release position (r' - r0)/r1 next to the absorbing wall.
-# The sampler's trapping rate and the inverse CDF table must use the same value.
+# Dimensionless release position (r' - r0)/r0 next to the absorbing inner
+# wall, so the release point is r' = r0*(1 + eps). The sampler's trapping
+# rate and the inverse CDF table must use the same value.
 RELEASE_EPS = 1e-2
 
 
@@ -30,7 +31,7 @@ def Psi_star_annulus(s, eps, tau0, tau1):
             Laplace variable values.
 
         eps : float
-            (r' - r0) / r1, dimensionless release position.
+            (r' - r0) / r0, dimensionless release position.
 
         tau0 : float
             r0^2 / D, inner-radius diffusion timescale.
@@ -89,26 +90,46 @@ def Psi_pdf_star_annulus(s, eps, tau0, tau1):
     return Psi_star_annulus(s, eps, tau0, tau1) * s
 
 
-def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, tau0=1e-4, tau1=1e3,
+def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, tau0_ratio=1e-7,
                      stehfest_n=16):
     """ Precompute the inverse CDF table for cylindrical annulus return-time sampling.
 
-    Parameters match Marco Dentz's InvLaplace.m defaults:
-    eps = 1e-2 dimensionless release position (r'-r0)/r1;
-    tau0 = 1e-4 inner-radius timescale r0^2/D;
-    tau1 = 1e3 outer-radius timescale r1^2/D.
+    The table is built in dimensionless time units of tau1 = r1^2/D (tau1 = 1
+    in the Laplace-domain solution), so sampled values are rescaled to
+    physical times by multiplying with the particle's tau_D = r1^2/D.
 
-    The time range starts at 1e-10 to ensure Stehfest samples large enough s
-    for correct early-time behavior (requires s >> (1/eps)^2 / tau0).
+    Parameters
+    ----------
+        num_samples : int
+            Number of points in the logspace time array. Default 100.
+
+        eps : float
+            Dimensionless release position (r'-r0)/r0. Default RELEASE_EPS.
+
+        tau0_ratio : float
+            Geometry ratio tau0/tau1 = (r0/r1)^2 with r0 the fracture-matrix
+            interface radius (half the aperture) and r1 the outer block
+            radius (half the fracture spacing).
+
+        stehfest_n : int
+            Number of Stehfest coefficients. Default 16.
+
+    Notes
+    -----
+        The time range starts well below eps^2 * tau0_ratio so Stehfest
+        samples large enough s for correct early-time behavior
+        (requires s >> (1/eps)^2 / tau0).
 
     Returns
     -------
         (times, cdf_vals) : tuple of np.ndarray
-            Inverse CDF lookup arrays for use with np.interp.
+            Inverse CDF lookup arrays (times in units of tau1) for use
+            with np.interp.
     """
-    times = np.logspace(-10, 2, num_samples)
+    t_lo = max(1e-16, 0.01 * eps**2 * tau0_ratio)
+    times = np.logspace(np.log10(t_lo), 1, num_samples)
     return build_inverse_cdf_table(Psi_star_annulus, times, stehfest_n=stehfest_n,
-                                   eps=eps, tau0=tau0, tau1=tau1)
+                                   eps=eps, tau0=tau0_ratio, tau1=1.0)
 
 
 def limited_matrix_diffusion_annulus(self, G):

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/annulus.py
@@ -166,4 +166,5 @@ def limited_matrix_diffusion_annulus(self, G):
 
         All other parameters are attached to the particle class.
     """
-    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)
+    eps = self.release_eps if self.release_eps is not None else RELEASE_EPS
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, eps)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/dentz.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/dentz.py
@@ -1,0 +1,87 @@
+"""
+.. module:: dentz.py
+   :synopsis: Finite matrix diffusion in a slab geometry (Dentz model).
+              Return times are sampled from the first-passage time CDF of
+              diffusion in a finite slab, inverted from the Laplace domain
+              with the Stehfest algorithm.
+"""
+
+import numpy as np
+
+from pydfnworks.dfnGraph.transport.tdrw.stehfest import build_inverse_cdf_table
+from pydfnworks.dfnGraph.transport.tdrw.trapping import poisson_trapping_diffusion_time
+
+# Dimensionless release position next to the absorbing wall. The sampler's
+# trapping rate and the inverse CDF table must use the same value.
+RELEASE_EPS = 1e-4
+
+
+def Psi_star(s, eps):
+    """ Laplace transform of the slab CDF Psi*_eps(s)
+
+    cosh((1-eps)*sqrt(s)) / (s * cosh(sqrt(s)))
+
+    Scaled form to avoid cosh overflow at large s:
+    cosh((1-eps)*q) / cosh(q) = exp(-eps*q) * (1 + exp(-2*(1-eps)*q)) / (1 + exp(-2*q))
+    where q = sqrt(s). Both exp terms decay for large q so no overflow.
+    """
+    q = np.sqrt(s)
+    num = np.exp(-eps * q) * (1.0 + np.exp(-2.0 * (1.0 - eps) * q))
+    den = 1.0 + np.exp(-2.0 * q)
+    return num / (den * s)
+
+
+def Psi_pdf_star(s, eps):
+    """ Laplace transform of the slab first-passage time PDF: psi*(s) = s * Psi*(s) """
+    return Psi_star(s, eps) * s
+
+
+def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, stehfest_n=16):
+    """ Precompute the inverse CDF table for slab (Dentz) return-time sampling.
+
+    Replaces the original mpmath.invertlaplace implementation with
+    Stehfest inversion in double precision -- orders of magnitude faster.
+
+    The scaled cosh formulation avoids overflow for all s values.
+    t_min=1e-10 ensures Stehfest samples s >> 1/eps^2 for correct
+    early-time behavior (eps=1e-4 requires s ~ 1e8, t ~ ln2/1e8 ~ 1e-9).
+
+    Parameters
+    ----------
+        num_samples : int
+            Number of points in the logspace time array. Default 100.
+
+        eps : float
+            Dimensionless release position. Default RELEASE_EPS.
+
+        stehfest_n : int
+            Number of Stehfest coefficients. Default 16.
+
+    Returns
+    -------
+        (times, cdf_vals) : tuple of np.ndarray
+            Inverse CDF lookup arrays for use with np.interp.
+    """
+    times = np.logspace(-10, 3, num_samples)
+    return build_inverse_cdf_table(Psi_star, times, stehfest_n=stehfest_n, eps=eps)
+
+
+def limited_matrix_diffusion_dentz(self, G):
+    """ Matrix diffusion with a finite slab matrix block (Dentz model)
+
+    Parameters
+    ----------
+        G : NetworkX graph
+            graph obtained from graph_flow
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        All parameters are attached to the particle class.
+        tau_D = fracture_spacing^2 / matrix_diffusivity rescales the
+        dimensionless sampled return times to physical times [s].
+    """
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/dentz.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/dentz.py
@@ -11,9 +11,53 @@ import numpy as np
 from pydfnworks.dfnGraph.transport.tdrw.stehfest import build_inverse_cdf_table
 from pydfnworks.dfnGraph.transport.tdrw.trapping import poisson_trapping_diffusion_time
 
-# Dimensionless release position next to the absorbing wall. The sampler's
-# trapping rate and the inverse CDF table must use the same value.
+# Default (maximum) dimensionless release position next to the absorbing
+# wall. The sampler's trapping rate and the inverse CDF table must use the
+# same value. The TDRW approximation is only valid for retardation times
+# well beyond the artifact scale (eps * B)^2 / D_m (the shortest matrix
+# excursion the discretization can represent), so eps is reduced below this
+# value when the block half-width B is large -- see choose_release_eps().
 RELEASE_EPS = 1e-4
+
+# Smallest eps the adaptive rule may select. Trapping events per particle
+# scale as 1/eps, so this floor bounds the cost of a single run.
+MIN_RELEASE_EPS = 1e-8
+
+# The artifact scale (eps * B)^2 / D_m is kept below this fraction of the
+# characteristic advective time.
+ARTIFACT_TIME_FRACTION = 1e-3
+
+
+def choose_release_eps(t_char, half_width, matrix_diffusivity):
+    """ Choose the release position eps for the slab (Dentz) model.
+
+    The model reproduces the continuum solution only for retardation times
+    t >> (eps * B)^2 / D_m. This picks eps so that artifact scale is at
+    most ARTIFACT_TIME_FRACTION of the characteristic advective time
+    t_char, capped at RELEASE_EPS (small blocks keep the default) and
+    floored at MIN_RELEASE_EPS (cost control; a warning is in order if the
+    floor binds).
+
+    Parameters
+    ----------
+        t_char : float
+            Characteristic advective time of the network [s], e.g. the
+            shortest-path travel time from inlet to outlet.
+
+        half_width : float
+            Matrix block half-width B = fracture_spacing / 2 [m].
+
+        matrix_diffusivity : float
+            Matrix diffusivity [m^2/s].
+
+    Returns
+    -------
+        eps : float
+            Release position for the table and the trapping rate.
+    """
+    eps = np.sqrt(
+        ARTIFACT_TIME_FRACTION * matrix_diffusivity * t_char) / half_width
+    return float(min(RELEASE_EPS, max(MIN_RELEASE_EPS, eps)))
 
 
 def Psi_star(s, eps):
@@ -43,13 +87,16 @@ def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, stehfest_n=16):
     Stehfest inversion in double precision -- orders of magnitude faster.
 
     The scaled cosh formulation avoids overflow for all s values.
-    t_min=1e-10 ensures Stehfest samples s >> 1/eps^2 for correct
-    early-time behavior (eps=1e-4 requires s ~ 1e8, t ~ ln2/1e8 ~ 1e-9).
+    The lower end of the time range scales with eps: Stehfest must sample
+    s >> 1/eps^2 for correct early-time behavior, so t_min << eps^2 in the
+    dimensionless units of tau_D.
 
     Parameters
     ----------
         num_samples : int
-            Number of points in the logspace time array. Default 100.
+            Minimum number of points in the logspace time array. Default
+            100. The actual count grows with the eps-dependent time range
+            so the density stays at >= 8 points per decade.
 
         eps : float
             Dimensionless release position. Default RELEASE_EPS.
@@ -62,7 +109,10 @@ def make_inverse_cdf(num_samples=100, eps=RELEASE_EPS, stehfest_n=16):
         (times, cdf_vals) : tuple of np.ndarray
             Inverse CDF lookup arrays for use with np.interp.
     """
-    times = np.logspace(-10, 3, num_samples)
+    t_lo = min(1e-10, 0.01 * eps**2)
+    decades = np.log10(1e3) - np.log10(t_lo)
+    num_samples = max(num_samples, int(8 * decades))
+    times = np.logspace(np.log10(t_lo), 3, num_samples)
     return build_inverse_cdf_table(Psi_star, times, stehfest_n=stehfest_n, eps=eps)
 
 
@@ -81,7 +131,8 @@ def limited_matrix_diffusion_dentz(self, G):
     Notes
     -----
         All parameters are attached to the particle class.
-        tau_D = fracture_spacing^2 / matrix_diffusivity rescales the
+        tau_D = (fracture_spacing/2)^2 / matrix_diffusivity rescales the
         dimensionless sampled return times to physical times [s].
     """
-    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)
+    eps = self.release_eps if self.release_eps is not None else RELEASE_EPS
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, eps)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
@@ -67,4 +67,5 @@ def limited_matrix_diffusion_from_file(self, G):
         load_finite_time_cdf during transport setup. Sampled times are
         rescaled by tau_D = (fracture_spacing/2)^2 / matrix_diffusivity.
     """
-    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)
+    eps = self.release_eps if self.release_eps is not None else RELEASE_EPS
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, eps)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
@@ -1,0 +1,70 @@
+"""
+.. module:: from_file.py
+   :synopsis: Finite matrix diffusion with a user-supplied return-time CDF.
+              The CDF table is read from a two-column ASCII file instead of
+              being derived from an analytic block geometry.
+"""
+
+import numpy as np
+
+from pydfnworks.general.logging import local_print_log
+from pydfnworks.dfnGraph.transport.tdrw.trapping import poisson_trapping_diffusion_time
+
+# Dimensionless release position next to the absorbing wall. The supplied CDF
+# table must have been generated with the same release position (this matches
+# the slab/Dentz convention, RELEASE_EPS in dentz.py).
+RELEASE_EPS = 1e-4
+
+
+def load_finite_time_cdf(tdrw_filename):
+    """ Load a matrix-diffusion return-time CDF from file.
+
+    Parameters
+    ----------
+        tdrw_filename : str
+            Path to a two-column ASCII file. Column 1: dimensionless return
+            times (rescaled by tau_D = fracture_spacing^2 / matrix_diffusivity
+            during transport). Column 2: cumulative probabilities in [0, 1],
+            strictly increasing.
+
+    Returns
+    -------
+        finite_md_times : np.ndarray
+            Return times for inverse CDF lookup.
+
+        finite_md_cdf : np.ndarray
+            Cumulative probabilities corresponding to finite_md_times.
+    """
+    data = np.genfromtxt(tdrw_filename)
+
+    if data.ndim != 2 or data.shape[1] < 2:
+        local_print_log(
+            f"Error. File {tdrw_filename} does not contain at least two columns.",
+            "error")
+
+    finite_md_times = data[:, 0]
+    finite_md_cdf = data[:, 1]
+
+    return finite_md_times, finite_md_cdf
+
+
+def limited_matrix_diffusion_from_file(self, G):
+    """ Matrix diffusion with limited block size using a CDF read from file
+
+    Parameters
+    ----------
+        G : NetworkX graph
+            graph obtained from graph_flow
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        All parameters are attached to the particle class. The inverse CDF
+        table (self.transfer_time, self.trans_prob) is loaded from file by
+        load_finite_time_cdf during transport setup. Sampled times are
+        rescaled by tau_D = fracture_spacing^2 / matrix_diffusivity.
+    """
+    self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/from_file.py
@@ -23,7 +23,7 @@ def load_finite_time_cdf(tdrw_filename):
     ----------
         tdrw_filename : str
             Path to a two-column ASCII file. Column 1: dimensionless return
-            times (rescaled by tau_D = fracture_spacing^2 / matrix_diffusivity
+            times (rescaled by tau_D = (fracture_spacing/2)^2 / matrix_diffusivity
             during transport). Column 2: cumulative probabilities in [0, 1],
             strictly increasing.
 
@@ -65,6 +65,6 @@ def limited_matrix_diffusion_from_file(self, G):
         All parameters are attached to the particle class. The inverse CDF
         table (self.transfer_time, self.trans_prob) is loaded from file by
         load_finite_time_cdf during transport setup. Sampled times are
-        rescaled by tau_D = fracture_spacing^2 / matrix_diffusivity.
+        rescaled by tau_D = (fracture_spacing/2)^2 / matrix_diffusivity.
     """
     self.delta_t_md = poisson_trapping_diffusion_time(self, G, RELEASE_EPS)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/infinite.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/infinite.py
@@ -1,0 +1,54 @@
+
+from scipy import special
+import numpy as np 
+
+def t_diff_unlimited(a, tf, xi):
+    """
+    This function returns one  diffusion time sample for a and tf assuming an unlimited matrix block size.  This is used throughout the limited block size sampling technique. 
+    
+    Parameters
+    -------------------
+        a : double
+         Constant parameter describing retention in the matrix. a = (matrix_porosity*matrix_diffusion)/aperture_length
+        
+        tf : double
+            Advective travel time
+        
+        xi : float
+            value between [0,1)
+   
+    Returns
+    --------------
+        t_diff : float
+            Total time diffusing the matrix
+            
+    Notes
+    -------------
+        For a random sample, sample xi from U[0,1). 
+        
+    """
+
+    return ((a * tf) / special.erfcinv(xi))**2
+
+def unlimited_matrix_diffusion(self, G):
+    """ Matrix diffusion with unlimited block size
+
+    Parameters
+    ----------
+        G : NetworkX graph
+            graph obtained from graph_flow
+
+    Returns
+    ----------
+        None
+
+    Notes
+    -----------
+        All parameters are attached to the particle class 
+
+    """
+
+    b = G.edges[self.curr_node, self.next_node]['b']
+    a_nondim = self.matrix_porosity * np.sqrt(self.matrix_diffusivity) / b
+    xi = np.random.uniform(size=1, low=0, high=1)[0]
+    self.delta_t_md = ((a_nondim * self.delta_t / special.erfcinv(xi))**2)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/roubinet.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/roubinet.py
@@ -1,8 +1,11 @@
+
 import numpy as np
 from scipy import special
 import mpmath as mp
 
 from pydfnworks.general.logging import local_print_log
+from pydfnworks.dfnGraph.transport.tdrw.infinite import t_diff_unlimited
+
 
 def get_fracture_segments(transfer_time,
                           fracture_length,
@@ -63,36 +66,6 @@ def get_fracture_segments(transfer_time,
         # otherwise, get the number of segments of length segment_length on the edge
         num_segments = int(np.ceil(fracture_length / segment_length))
         return segment_length, num_segments
-
-
-def t_diff_unlimited(a, tf, xi):
-    """
-    This function returns one  diffusion time sample for a and tf assuming an unlimited matrix block size.  This is used throughout the limited block size sampling technique. 
-    
-    Parameters
-    -------------------
-        a : double
-         Constant parameter describing retention in the matrix. a = (matrix_porosity*matrix_diffusion)/aperture_length
-        
-        tf : double
-            Advective travel time
-        
-        xi : float
-            value between [0,1)
-   
-    Returns
-    --------------
-        t_diff : float
-            Total time diffusing the matrix
-            
-    Notescx
-    -------------
-        For a random sample, sample xi from U[0,1). 
-        
-    """
-
-    return ((a * tf) / special.erfcinv(xi))**2
-
 
 def transition_probability_cdf(t_min, t_max, frac_spacing, matrix_diffusivity,
                                num_pts):
@@ -240,9 +213,6 @@ def transfer_probabilities(b_min,
     a_max = (matrix_porosity * np.sqrt(matrix_diffusivity)) / b_min
     # sample at the largest value of tf, with sample ~ 1
     t_diff_ub = t_diff_unlimited(a_max, tf_max, 1 - eps)
-    # if t_diff_ub > 1e30:
-    #     print(f"ub too high {t_diff_ub} changing to 1e30")
-    #     t_diff_ub = 1e30
 
     local_print_log(
         f"--> Initial bounds for diffusion times. Min: {t_diff_lb:0.2e}, Max: {t_diff_ub:0.2e}"
@@ -282,8 +252,6 @@ def transfer_probabilities(b_min,
 
     #convert to as dictionary
     trans_prob = {"times": times, "cdf": trans_cdf}
-    # print(times)
-    # print(trans_cdf)
     return trans_prob
 
 
@@ -433,58 +401,7 @@ def get_aperture_and_time_limits(G):
     return b_min, b_max, t_min, t_max
 
 
-def set_up_limited_matrix_diffusion(G,
-                                    frac_spacing,
-                                    matrix_porosity,
-                                    matrix_diffusivity,
-                                    eps=1e-16,
-                                    num_pts=100):
-    """ Sets up transition probabilities for limited block size matrix diffusion
-    
-    Parameters
-    ---------------------
-        G : networkX graph  
-            Graph provided by graph_flow modules
-
-        fracture_length : float
-            Length of the current edge segment in the graph [m]
-
-        matrix_porosity: float
-            Matrix Porosity 
-
-        matrix_diffusivity : float
-            Matrix Diffusivity value  [m^2/s]
-
-        eps : float 
-            Default - 1e-16
-
-        num_pts : int 
-            Number of points in the logspace array between t_min and t_max
- 
-
-    Returns
-    -------------
-        trans_prob : dictionary 
-            Dictionary elements
-            times : np.array
-                Array of diffusion times 
-            prob_cdf : np.array
-                Array of cummulative probabilities. They only go to 0.5
-
-    Notes
-    --------------------
-        None
-
-    """
-
-    b_min, b_max, tf_min, tf_max = get_aperture_and_time_limits(G)
-    trans_prob = transfer_probabilities(b_min, b_max, tf_min, tf_max,
-                                        matrix_porosity, matrix_diffusivity,
-                                        frac_spacing, eps, num_pts)
-    return trans_prob
-
-
-def limited_matrix_diffusion(self, G):
+def limited_matrix_diffusion_roubinet(self, G):
     """ Matrix diffusion with limited block size
 
     Parameters
@@ -516,25 +433,4 @@ def limited_matrix_diffusion(self, G):
                                                num_segments)
 
 
-def unlimited_matrix_diffusion(self, G):
-    """ Matrix diffusion with unlimited block size
 
-    Parameters
-    ----------
-        G : NetworkX graph
-            graph obtained from graph_flow
-
-    Returns
-    ----------
-        None
-
-    Notes
-    -----------
-        All parameters are attached to the particle class 
-
-    """
-
-    b = G.edges[self.curr_node, self.next_node]['b']
-    a_nondim = self.matrix_porosity * np.sqrt(self.matrix_diffusivity) / b
-    xi = np.random.uniform(size=1, low=0, high=1)[0]
-    self.delta_t_md = ((a_nondim * self.delta_t / special.erfcinv(xi))**2)

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
@@ -5,6 +5,7 @@
 """
 
 import os
+import numpy as np
 
 from pydfnworks.general.logging import local_print_log
 import pydfnworks.dfnGraph.transport.tdrw.infinite as infinite
@@ -33,8 +34,9 @@ def check_tdrw_params(matrix_porosity, matrix_diffusivity, fracture_spacing,
             Effective diffusivity of the rock matrix [m^2/s]
 
         fracture_spacing : float
-            Characteristic matrix block half-width / fracture spacing [m]
-            Required for finite matrix models.
+            Distance between adjacent parallel fractures [m]; the matrix
+            block half-width is fracture_spacing/2. Required for finite
+            matrix models.
 
         tdrw_model : str
             Name of the TDRW matrix diffusion model. Valid options:
@@ -146,7 +148,8 @@ def set_up_limited_matrix_diffusion(G,
             'roubinet', 'dentz', 'annulus', 'from_file'.
 
         fracture_spacing : float
-            Characteristic matrix block half-width [m]. Required for all
+            Distance between adjacent parallel fractures [m]; the matrix
+            block half-width is fracture_spacing/2. Required for all
             finite models.
 
         matrix_porosity : float
@@ -195,10 +198,22 @@ def set_up_limited_matrix_diffusion(G,
         transfer_time, trans_prob = dentz.make_inverse_cdf(num_samples=num_pts)
 
     elif tdrw_model == "annulus":
-        # annulus model: absorbing wall at fracture-matrix interface,
-        # reflecting wall at block interior; eps fixed inside the module
+        # annulus model: absorbing wall at fracture-matrix interface
+        # (r0 = aperture/2), reflecting wall at block interior
+        # (r1 = fracture_spacing/2); eps fixed inside the module.
+        # A single table is used for the whole network, built with a
+        # representative r0 from the geometric mean of the edge apertures.
+        b_edges = np.array([d['b'] for _, _, d in G.edges(data=True)])
+        b_rep = float(np.exp(np.log(b_edges).mean()))
+        r0 = b_rep / 2
+        r1 = fracture_spacing / 2
+        tau0_ratio = (r0 / r1)**2
+        local_print_log(
+            f"--> Annulus geometry: representative r0 = {r0:0.2e} m "
+            f"(geometric-mean aperture / 2), r1 = {r1:0.2e} m, "
+            f"(r0/r1)^2 = {tau0_ratio:0.2e}")
         transfer_time, trans_prob = annulus.make_inverse_cdf(
-            num_samples=num_pts)
+            num_samples=num_pts, tau0_ratio=tau0_ratio)
 
     elif tdrw_model == "from_file":
         transfer_time, trans_prob = from_file.load_finite_time_cdf(

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
@@ -1,0 +1,211 @@
+"""
+.. module:: setup.py
+   :synopsis: Parameter validation and inverse-CDF setup for TDRW matrix
+              diffusion models used in graph particle transport.
+"""
+
+import os
+
+from pydfnworks.general.logging import local_print_log
+import pydfnworks.dfnGraph.transport.tdrw.infinite as infinite
+import pydfnworks.dfnGraph.transport.tdrw.roubinet as roubinet
+import pydfnworks.dfnGraph.transport.tdrw.dentz as dentz
+import pydfnworks.dfnGraph.transport.tdrw.annulus as annulus
+import pydfnworks.dfnGraph.transport.tdrw.from_file as from_file
+
+# Valid finite matrix diffusion models. All of them require fracture_spacing:
+# it sets the block size for the analytic models and the timescale
+# tau_D = fracture_spacing^2 / matrix_diffusivity for the tabulated ones.
+FINITE_MODELS = ("roubinet", "dentz", "annulus", "from_file")
+VALID_MODELS = ("infinite", ) + FINITE_MODELS
+
+
+def check_tdrw_params(matrix_porosity, matrix_diffusivity, fracture_spacing,
+                      tdrw_model, tdrw_filename):
+    """ Check that the provided tdrw values are physical
+
+    Parameters
+    ----------
+        matrix_porosity : float
+            Porosity of the rock matrix [-]
+
+        matrix_diffusivity : float
+            Effective diffusivity of the rock matrix [m^2/s]
+
+        fracture_spacing : float
+            Characteristic matrix block half-width / fracture spacing [m]
+            Required for finite matrix models.
+
+        tdrw_model : str
+            Name of the TDRW matrix diffusion model. Valid options:
+            'infinite', 'roubinet', 'dentz', 'annulus', 'from_file'.
+
+        tdrw_filename : str or None
+            Path to CDF file, required when tdrw_model == 'from_file'.
+
+    Returns
+    -------
+        None
+
+    Notes
+    -----
+        Logs errors and warnings via local_print_log. Errors logged with
+        level 'error' are fatal.
+    """
+    local_print_log("\n* TDRW for Matrix Diffusion is ON.")
+
+    # --- Matrix Porosity ---
+    if matrix_porosity is None:
+        local_print_log(
+            "Error: Requested TDRW but no value for matrix_porosity was provided.",
+            "error")
+    elif not (0 <= matrix_porosity <= 1):
+        local_print_log(
+            f"Error: Requested TDRW but matrix_porosity={matrix_porosity} is outside the valid range [0, 1].",
+            "error")
+    else:
+        local_print_log(f"--> Matrix porosity value: {matrix_porosity:.2f} [-]")
+
+    # --- Matrix Diffusivity ---
+    if matrix_diffusivity is None:
+        local_print_log(
+            "Error: Requested TDRW but no value for matrix_diffusivity was provided.",
+            "error")
+    elif matrix_diffusivity <= 0:
+        local_print_log(
+            f"Error: Non-positive matrix_diffusivity={matrix_diffusivity}. Exiting program.",
+            "error")
+    else:
+        local_print_log(
+            f"--> Matrix diffusivity value: {matrix_diffusivity:.2e} [m^2/s]")
+
+    # --- TDRW Model Selection ---
+    if tdrw_model == "infinite":
+        local_print_log(
+            "--> Using infinite matrix diffusion model (no fracture spacing required)."
+        )
+
+    elif tdrw_model in FINITE_MODELS:
+        local_print_log(
+            f"--> Using {tdrw_model.capitalize()} model for finite matrix diffusion."
+        )
+        # --- Fracture Spacing Check ---
+        if fracture_spacing is None:
+            local_print_log(
+                f"Error: TDRW model '{tdrw_model}' requires a fracture_spacing value, but none was provided.",
+                "error")
+        elif fracture_spacing <= 0:
+            local_print_log(
+                f"Error: Non-positive fracture_spacing={fracture_spacing}. Exiting program.",
+                "error")
+        else:
+            local_print_log(
+                f"--> Fracture spacing value: {fracture_spacing:.2e} [m]")
+
+        if tdrw_model == "annulus":
+            local_print_log(
+                "--> Annulus geometry: absorbing boundary at fracture-matrix interface, reflecting boundary at block interior."
+            )
+
+        if tdrw_model == "from_file":
+            if tdrw_filename is None:
+                local_print_log("Error. TDRW Filename not provided.", "error")
+            elif not os.path.isfile(tdrw_filename):
+                local_print_log(f"Error. File not found: {tdrw_filename}",
+                                "error")
+            else:
+                local_print_log(
+                    f"--> Sampling matrix diffusion time from: {tdrw_filename}."
+                )
+
+    else:
+        local_print_log(
+            f"Error: Unknown TDRW model '{tdrw_model}'. Valid options are 'infinite', 'roubinet', 'dentz', 'annulus', or 'from_file' (case-sensitive).",
+            "error")
+
+    local_print_log("")  # clean trailing newline
+
+
+def set_up_limited_matrix_diffusion(G,
+                                    tdrw_model,
+                                    fracture_spacing,
+                                    matrix_porosity,
+                                    matrix_diffusivity,
+                                    eps=1e-16,
+                                    num_pts=100,
+                                    tdrw_filename=None):
+    """ Sets up transition probabilities for limited block size matrix diffusion
+
+    Parameters
+    ----------
+        G : networkX graph
+            Graph provided by graph_flow modules
+
+        tdrw_model : str
+            Name of the TDRW matrix diffusion model. Valid options:
+            'roubinet', 'dentz', 'annulus', 'from_file'.
+
+        fracture_spacing : float
+            Characteristic matrix block half-width [m]. Required for all
+            finite models.
+
+        matrix_porosity : float
+            Matrix porosity [-]
+
+        matrix_diffusivity : float
+            Matrix diffusivity [m^2/s]
+
+        eps : float
+            Small parameter for Roubinet model. Default 1e-16.
+
+        num_pts : int
+            Number of points in the logspace CDF table. Default 100.
+
+        tdrw_filename : str or None
+            Path to CDF file, required when tdrw_model == 'from_file'.
+
+    Returns
+    -------
+        transfer_time : np.ndarray or float or None
+            Roubinet: characteristic transfer time across the block [s].
+            Dentz/annulus/from_file: array of dimensionless diffusion return
+            times for inverse CDF lookup.
+
+        trans_prob : np.ndarray or dict or None
+            Roubinet: dictionary with the transition-probability CDF.
+            Dentz/annulus/from_file: array of cumulative probabilities
+            corresponding to transfer_time.
+
+    Notes
+    -----
+        The returned arrays are used with np.interp to map uniform random
+        samples to return times during particle transport. See
+        limited_matrix_diffusion_* functions in each model module.
+    """
+    if tdrw_model == "roubinet":
+        b_min, b_max, tf_min, tf_max = roubinet.get_aperture_and_time_limits(G)
+        trans_prob = roubinet.transfer_probabilities(b_min, b_max, tf_min,
+                                                     tf_max, matrix_porosity,
+                                                     matrix_diffusivity,
+                                                     fracture_spacing, eps,
+                                                     num_pts)
+        transfer_time = fracture_spacing**2 / (2 * matrix_diffusivity)
+
+    elif tdrw_model == "dentz":
+        transfer_time, trans_prob = dentz.make_inverse_cdf(num_samples=num_pts)
+
+    elif tdrw_model == "annulus":
+        # annulus model: absorbing wall at fracture-matrix interface,
+        # reflecting wall at block interior; eps fixed inside the module
+        transfer_time, trans_prob = annulus.make_inverse_cdf(
+            num_samples=num_pts)
+
+    elif tdrw_model == "from_file":
+        transfer_time, trans_prob = from_file.load_finite_time_cdf(
+            tdrw_filename)
+
+    else:
+        trans_prob = None
+        transfer_time = None
+
+    return transfer_time, trans_prob

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/setup.py
@@ -6,6 +6,7 @@
 
 import os
 import numpy as np
+import networkx as nx
 
 from pydfnworks.general.logging import local_print_log
 import pydfnworks.dfnGraph.transport.tdrw.infinite as infinite
@@ -179,12 +180,19 @@ def set_up_limited_matrix_diffusion(G,
             Dentz/annulus/from_file: array of cumulative probabilities
             corresponding to transfer_time.
 
+        release_eps : float or None
+            Dimensionless release position used to build the table; the
+            trapping rate must use the same value. For dentz it is chosen
+            adaptively (see dentz.choose_release_eps). None for roubinet,
+            which has no release-position parameter.
+
     Notes
     -----
         The returned arrays are used with np.interp to map uniform random
         samples to return times during particle transport. See
         limited_matrix_diffusion_* functions in each model module.
     """
+    release_eps = None
     if tdrw_model == "roubinet":
         b_min, b_max, tf_min, tf_max = roubinet.get_aperture_and_time_limits(G)
         trans_prob = roubinet.transfer_probabilities(b_min, b_max, tf_min,
@@ -195,7 +203,29 @@ def set_up_limited_matrix_diffusion(G,
         transfer_time = fracture_spacing**2 / (2 * matrix_diffusivity)
 
     elif tdrw_model == "dentz":
-        transfer_time, trans_prob = dentz.make_inverse_cdf(num_samples=num_pts)
+        # The slab TDRW only reproduces the continuum solution for
+        # retardation times well beyond (release_eps * B)^2 / D_m, so the
+        # release position shrinks with the block half-width. The
+        # characteristic advective time is the fastest source-to-target
+        # path; using the fastest (rather than a typical) path keeps the
+        # artifact below the earliest arrivals.
+        t_char = characteristic_advective_time(G)
+        half_width = fracture_spacing / 2
+        release_eps = dentz.choose_release_eps(t_char, half_width,
+                                               matrix_diffusivity)
+        artifact_time = (release_eps * half_width)**2 / matrix_diffusivity
+        local_print_log(
+            f"--> Dentz release position eps = {release_eps:0.2e} "
+            f"(characteristic advective time {t_char:0.2e} s, "
+            f"artifact timescale {artifact_time:0.2e} s)")
+        if release_eps == dentz.MIN_RELEASE_EPS:
+            local_print_log(
+                "--> Warning: Dentz release eps hit its floor "
+                f"({dentz.MIN_RELEASE_EPS:0.0e}); breakthrough curves are "
+                "only accurate for retardation times "
+                f">~ {artifact_time:0.2e} s.", "warning")
+        transfer_time, trans_prob = dentz.make_inverse_cdf(
+            num_samples=num_pts, eps=release_eps)
 
     elif tdrw_model == "annulus":
         # annulus model: absorbing wall at fracture-matrix interface
@@ -212,10 +242,12 @@ def set_up_limited_matrix_diffusion(G,
             f"--> Annulus geometry: representative r0 = {r0:0.2e} m "
             f"(geometric-mean aperture / 2), r1 = {r1:0.2e} m, "
             f"(r0/r1)^2 = {tau0_ratio:0.2e}")
+        release_eps = annulus.RELEASE_EPS
         transfer_time, trans_prob = annulus.make_inverse_cdf(
             num_samples=num_pts, tau0_ratio=tau0_ratio)
 
     elif tdrw_model == "from_file":
+        release_eps = from_file.RELEASE_EPS
         transfer_time, trans_prob = from_file.load_finite_time_cdf(
             tdrw_filename)
 
@@ -223,4 +255,35 @@ def set_up_limited_matrix_diffusion(G,
         trans_prob = None
         transfer_time = None
 
-    return transfer_time, trans_prob
+    return transfer_time, trans_prob, release_eps
+
+
+def characteristic_advective_time(G):
+    """ Characteristic advective time of the flow network [s]: the fastest
+    advective source-to-target path. Falls back to the smallest positive
+    edge travel time if no path exists (conservative: a smaller value only
+    tightens the adaptive release position).
+
+    Parameters
+    ----------
+        G : networkX graph
+            Graph provided by graph_flow, with edge attribute 'time' and
+            virtual source 's' / target 't' vertices.
+
+    Returns
+    -------
+        t_char : float
+            Characteristic advective time [s].
+    """
+    try:
+        return nx.shortest_path_length(
+            G, 's', 't', weight=lambda u, v, d: d.get('time', 0.0))
+    except (nx.NetworkXNoPath, nx.NodeNotFound):
+        times = np.array(
+            [d.get('time', 0.0) for _, _, d in G.edges(data=True)])
+        times = times[times > 0]
+        if len(times) == 0:
+            local_print_log(
+                "Error: cannot determine a characteristic advective time: "
+                "no positive edge travel times in the graph.", "error")
+        return float(times.min())

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/stehfest.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/stehfest.py
@@ -1,0 +1,104 @@
+"""
+.. module:: stehfest.py
+   :synopsis: Gaver-Stehfest numerical Laplace inversion, shared by the
+              finite matrix-diffusion TDRW models (dentz, annulus)
+"""
+
+import numpy as np
+from math import factorial
+
+
+def stehfest_coefficients(N=16):
+    """ Compute Stehfest coefficients V_i for i = 1 ... N.
+
+    Parameters
+    ----------
+        N : int
+            Number of coefficients. Must be even. Default 16.
+
+    Returns
+    -------
+        V : np.ndarray
+            Array of N Stehfest coefficients.
+    """
+    if N % 2 != 0:
+        raise ValueError("Stehfest N must be even.")
+    M = N // 2
+    V = np.zeros(N)
+    for i in range(1, N + 1):
+        total = 0.0
+        for k in range(int((i + 1) // 2), min(i, M) + 1):
+            num = (k ** M) * factorial(2 * k)
+            den = (factorial(M - k) * factorial(k) * factorial(k - 1)
+                   * factorial(i - k) * factorial(2 * k - i))
+            total += num / den
+        V[i - 1] = ((-1) ** (i + M)) * total
+    return V
+
+
+def stehfest_invert(F, t_arr, V, **kwargs):
+    """ Invert the Laplace transform F at times t_arr using the Stehfest algorithm.
+
+    f(t) ~ (ln2/t) * sum_i V_i * F(i*ln2/t)
+
+    Parameters
+    ----------
+        F : callable
+            Laplace-domain function F(s, **kwargs). Must accept a numpy array of s values.
+
+        t_arr : np.ndarray
+            Times at which to evaluate the inverse transform.
+
+        V : np.ndarray
+            Stehfest coefficients from stehfest_coefficients().
+
+    Returns
+    -------
+        f : np.ndarray
+            Approximate inverse transform evaluated at t_arr.
+    """
+    ln2 = np.log(2.0)
+    f = np.zeros(len(t_arr))
+    for idx, ti in enumerate(t_arr):
+        s_vals = np.array([(i + 1) * ln2 / ti for i in range(len(V))])
+        f[idx] = (ln2 / ti) * np.dot(V, F(s_vals, **kwargs))
+    return f
+
+
+def build_inverse_cdf_table(F_cdf, times, stehfest_n=16, **kwargs):
+    """ Precompute an inverse CDF lookup table by Stehfest inversion of a
+    Laplace-domain CDF.
+
+    Parameters
+    ----------
+        F_cdf : callable
+            Laplace transform of the CDF, F_cdf(s, **kwargs).
+
+        times : np.ndarray
+            Time points (typically logspaced) at which to invert the CDF.
+
+        stehfest_n : int
+            Number of Stehfest coefficients. Default 16.
+
+    Returns
+    -------
+        t_unique : np.ndarray
+            Return times, sorted by CDF value, for use with np.interp.
+
+        cdf_unique : np.ndarray
+            Strictly increasing cumulative probabilities in [0, 1]
+            corresponding to t_unique.
+    """
+    V = stehfest_coefficients(stehfest_n)
+    cdf_vals = stehfest_invert(F_cdf, times, V, **kwargs)
+
+    # sort by cdf value to build the inverse CDF (cdf -> time) lookup
+    order = np.argsort(cdf_vals)
+    cdf_sorted = np.clip(cdf_vals[order], 0, 1)
+    t_sorted = np.maximum(times[order], 0)
+
+    # remove duplicate cdf values to ensure monotone interpolation
+    cdf_unique, idx = np.unique(cdf_sorted, return_index=True)
+    t_unique = np.asarray(t_sorted[idx])
+
+    return t_unique, cdf_unique

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/stehfest.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/stehfest.py
@@ -92,13 +92,15 @@ def build_inverse_cdf_table(F_cdf, times, stehfest_n=16, **kwargs):
     V = stehfest_coefficients(stehfest_n)
     cdf_vals = stehfest_invert(F_cdf, times, V, **kwargs)
 
-    # sort by cdf value to build the inverse CDF (cdf -> time) lookup
-    order = np.argsort(cdf_vals)
-    cdf_sorted = np.clip(cdf_vals[order], 0, 1)
-    t_sorted = np.maximum(times[order], 0)
+    # Enforce monotonicity with a running maximum along the time axis. This
+    # preserves the (time, cdf) pairing; sorting by cdf value instead would
+    # scramble pairs wherever Stehfest ringing exceeds the spacing between
+    # adjacent cdf values, which biases sampled return times high and gets
+    # worse -- not better -- as the table is refined.
+    cdf_mono = np.maximum.accumulate(np.clip(cdf_vals, 0.0, 1.0))
 
     # remove duplicate cdf values to ensure monotone interpolation
-    cdf_unique, idx = np.unique(cdf_sorted, return_index=True)
-    t_unique = np.asarray(t_sorted[idx])
+    cdf_unique, idx = np.unique(cdf_mono, return_index=True)
+    t_unique = np.asarray(times[idx])
 
     return t_unique, cdf_unique

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/trapping.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/trapping.py
@@ -38,9 +38,14 @@ def poisson_trapping_diffusion_time(particle, G, eps):
     """
     b = G.edges[particle.curr_node, particle.next_node]['b']
 
-    # trapping rate into the matrix block
+    # trapping rate into the matrix block. The matrix half-width is half the
+    # spacing between adjacent fractures (matching the roubinet model's
+    # interpretation of fracture_spacing), and the factor 2/b converts the
+    # full edge aperture to the half-aperture of the two-sided exchange:
+    # gamma = phi_m * D_m / (b_f * eps * B) with b_f = b/2, B = spacing/2.
+    half_width = particle.fracture_spacing / 2
     gamma = (2 * particle.matrix_porosity * particle.matrix_diffusivity) / (
-        b * eps * particle.fracture_spacing)
+        b * eps * half_width)
 
     # average number of trapping events during this advective step
     average_number_of_trapping_events = particle.delta_t * gamma

--- a/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/trapping.py
+++ b/pydfnworks/pydfnworks/dfnGraph/transport/tdrw/trapping.py
@@ -1,0 +1,56 @@
+"""
+.. module:: trapping.py
+   :synopsis: Shared Poisson trapping-event sampler used by the finite
+              matrix-diffusion TDRW models (dentz, annulus, from_file)
+"""
+
+import numpy as np
+
+
+def poisson_trapping_diffusion_time(particle, G, eps):
+    """ Sample the total matrix-diffusion time accrued during one advective
+    step using the Poisson trapping-event model.
+
+    The number of trapping events over the step is Poisson-distributed with
+    rate gamma * delta_t, where gamma is the trapping rate into the matrix.
+    Each event's return time is drawn from the model's precomputed inverse
+    CDF table (particle.transfer_time / particle.trans_prob) and rescaled
+    from dimensionless to physical time by particle.tau_D.
+
+    Parameters
+    ----------
+        particle : Particle
+            Particle object. Uses matrix_porosity, matrix_diffusivity,
+            fracture_spacing, delta_t, tau_D, trans_prob, transfer_time.
+
+        G : NetworkX graph
+            graph obtained from graph_flow
+
+        eps : float
+            Dimensionless release position of the particle next to the
+            absorbing fracture-matrix interface. Must match the eps used
+            to build the inverse CDF table.
+
+    Returns
+    -------
+        delta_t_md : float
+            Total matrix diffusion time for this advective step [s].
+    """
+    b = G.edges[particle.curr_node, particle.next_node]['b']
+
+    # trapping rate into the matrix block
+    gamma = (2 * particle.matrix_porosity * particle.matrix_diffusivity) / (
+        b * eps * particle.fracture_spacing)
+
+    # average number of trapping events during this advective step
+    average_number_of_trapping_events = particle.delta_t * gamma
+
+    # sample number of trapping events from Poisson distribution
+    n = np.random.poisson(average_number_of_trapping_events)
+
+    # sample uniform random variables and map to return times via inverse CDF
+    xi = np.random.uniform(size=n)
+    return_times = particle.tau_D * np.interp(xi, particle.trans_prob,
+                                              particle.transfer_time)
+
+    return return_times.sum()

--- a/pydfnworks/tests/tdrw/run_tdrw_verification.py
+++ b/pydfnworks/tests/tdrw/run_tdrw_verification.py
@@ -1,0 +1,55 @@
+"""
+run_tdrw_verification.py
+------------------------
+Runs all TDRW matrix diffusion verification tests and prints a summary.
+
+Usage:
+    python run_tdrw_verification.py
+
+Runs:
+    verify_slab_tdrw.py    -- slab model vs Sudicky-Frind (1982)
+    verify_annulus_tdrw.py -- cylindrical annulus model vs analytical CDF
+
+Exits with code 0 if all tests pass, 1 if any fail.
+"""
+
+import sys
+import subprocess
+import os
+
+SCRIPTS = [
+    ("verify_slab_tdrw.py",    "Slab (Dentz) TDRW"),
+    ("verify_annulus_tdrw.py", "Cylindrical Annulus TDRW"),
+]
+
+def run_script(path, label):
+    print(f"\n{'='*60}")
+    print(f"  Running: {label}")
+    print(f"  Script:  {path}")
+    print(f"{'='*60}")
+    result = subprocess.run(
+        [sys.executable, path],
+        capture_output=False
+    )
+    return result.returncode == 0
+
+if __name__ == "__main__":
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    all_passed = True
+    summary    = []
+
+    for script, label in SCRIPTS:
+        path   = os.path.join(script_dir, script)
+        passed = run_script(path, label)
+        all_passed = all_passed and passed
+        summary.append((label, passed))
+
+    print(f"\n{'='*60}")
+    print("  TDRW Verification Summary")
+    print(f"{'='*60}")
+    for label, passed in summary:
+        status = "PASS" if passed else "FAIL"
+        print(f"  [{status}]  {label}")
+    print(f"{'='*60}")
+
+    sys.exit(0 if all_passed else 1)

--- a/pydfnworks/tests/tdrw/verify_annulus_tdrw.py
+++ b/pydfnworks/tests/tdrw/verify_annulus_tdrw.py
@@ -1,0 +1,432 @@
+"""
+verify_annulus_tdrw.py
+----------------------
+Verification script for tdrw_finite_annulus.py (cylindrical annulus TDRW).
+
+Designed for Claude Code: imports the dfnWorks module under test and compares
+it against the analytical first-passage time CDF for cylindrical diffusion.
+
+Tests
+-----
+  1. Annulus psi*(s) Laplace limiting behavior: psi*(0)=1, psi*(inf)=0
+  2. Bessel branch switch consistency at |s*tau1| = 100
+  3. Wronskian identity check on the denominator
+  4. Inverse CDF table from _make_inverse_cdf_annulus:
+       monotone, starts at 0, ends at 1
+  5. Monte Carlo vs analytical first-passage time CDF at 10 quantiles
+  6. Thin-shell limit: cylindrical CDF -> slab CDF as r1/r0 -> 1
+  7. Mean matrix diffusion time sanity check
+
+Run with:
+    python verify_annulus_tdrw.py
+
+All tests print PASS / FAIL with numerical details.
+Exits with code 0 (all pass) or 1 (any fail).
+
+Reference
+---------
+First-passage time for cylindrical diffusion derived from the backward
+Kolmogorov equation; see matrix_diffusion_verification.pdf.
+"""
+
+import sys
+import numpy as np
+from math import factorial
+from scipy.special import iv, kv, ive, kve
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+from pydfnworks.dfnGraph.transport.tdrw.annulus import (
+    Psi_star_annulus,
+    make_inverse_cdf,
+)
+from pydfnworks.dfnGraph.transport.tdrw.stehfest import (
+    stehfest_coefficients as _stehfest_coefficients, )
+
+print("Testing pydfnworks.dfnGraph.transport.tdrw.annulus")
+
+
+def _make_inverse_cdf_annulus(num_samples=100, eps=1e-2, tau0=1e-4, tau1=1e3,
+                              stehfest_n=16):
+    # the ported builder is tau1-normalized; only the geometry ratio
+    # tau0/tau1 = (r0/r1)^2 matters, and returned times are in units of tau1
+    return make_inverse_cdf(num_samples=num_samples, eps=eps,
+                            tau0_ratio=tau0 / tau1, stehfest_n=stehfest_n)
+
+# ---------------------------------------------------------------------------
+# Reference implementations (independent of the module under test)
+# ---------------------------------------------------------------------------
+
+def _ref_stehfest(N=16):
+    M = N // 2
+    V = np.zeros(N)
+    for i in range(1, N + 1):
+        total = 0.0
+        for k in range(int((i + 1) // 2), min(i, M) + 1):
+            num = (k ** M) * factorial(2 * k)
+            den = (factorial(M - k) * factorial(k) * factorial(k - 1)
+                   * factorial(i - k) * factorial(2 * k - i))
+            total += num / den
+        V[i - 1] = ((-1) ** (i + M)) * total
+    return V
+
+
+def _stehfest_invert(F, t_arr, V, **kw):
+    ln2 = np.log(2.0)
+    f   = np.zeros(len(t_arr))
+    for idx, t in enumerate(t_arr):
+        sv  = np.array([(i + 1) * ln2 / t for i in range(len(V))])
+        f[idx] = (ln2 / t) * np.dot(V, F(sv, **kw))
+    return f
+
+
+def _annulus_psi_ref(s, eps, tau0, tau1):
+    """
+    Reference implementation of the cylindrical annulus psi*(s).
+    Uses branch switch at |s*tau1|=100 matching the module under test.
+
+    F_psi(s) = [I0((1+eps)*q0)*K1(q1) + K0((1+eps)*q0)*I1(q1)]
+             / [I0(q0)*K1(q1) + K0(q0)*I1(q1)]
+    """
+    q0     = np.sqrt(s * tau0)
+    q0_eps = (1.0 + eps) * q0
+    q1     = np.sqrt(s * tau1)
+    large  = s * tau1 > 100
+
+    # large-argument branch (scaled Bessels)
+    I0e_eps = ive(0, q0_eps);  K0e_eps = kve(0, q0_eps)
+    I0e_0   = ive(0, q0);      K0e_0   = kve(0, q0)
+    I1e_1   = ive(1, q1);      K1e_1   = kve(1, q1)
+    exp1 = np.exp(np.clip((2 + eps) * q0 - 2 * q1, -500, 500))
+    exp2 = np.exp(np.clip(-eps * q0,               -500, 500))
+    expd = np.exp(np.clip(2 * q0 - 2 * q1,          -500, 500))
+    num_l = exp1 * I0e_eps * K1e_1 + exp2 * K0e_eps * I1e_1
+    den_l = expd * I0e_0   * K1e_1 +        K0e_0   * I1e_1
+
+    # small-argument branch (unscaled Bessels)
+    with np.errstate(invalid='ignore', over='ignore'):
+        num_s = iv(0, q0_eps) * kv(1, q1) + kv(0, q0_eps) * iv(1, q1)
+        den_s = iv(0, q0)     * kv(1, q1) + kv(0, q0)     * iv(1, q1)
+
+    num = np.where(large, num_l, num_s)
+    den = np.where(large, den_l, den_s)
+    return num / den
+
+
+def _annulus_cdf_ref(s, eps, tau0, tau1):
+    return _annulus_psi_ref(s, eps, tau0, tau1) / s
+
+
+def _slab_psi_ref(s, eps):
+    """Slab psi*(s), scaled form."""
+    q = np.sqrt(s)
+    return (np.exp(-eps * q) * (1.0 + np.exp(-2.0 * (1.0 - eps) * q))
+            / (1.0 + np.exp(-2.0 * q)))
+
+
+def _slab_cdf_ref(s, eps):
+    return _slab_psi_ref(s, eps) / s
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+RESULTS = []
+
+def check(name, passed, detail=""):
+    status = "PASS" if passed else "FAIL"
+    msg    = f"  [{status}] {name}"
+    if detail:
+        msg += f"\n         {detail}"
+    print(msg)
+    RESULTS.append((name, passed))
+
+
+def close(a, b, tol):
+    return abs(a - b) / max(abs(b), 1e-30) < tol
+
+# ---------------------------------------------------------------------------
+# Test 1: Laplace-domain limiting behavior
+# ---------------------------------------------------------------------------
+
+def test_psi_limits():
+    print("\nTest 1: psi*(s) limiting behavior")
+    eps  = 1e-2
+    tau0 = 1e-4
+    tau1 = 1e3
+
+    # Note: Psi_star_annulus returns the CDF transform (includes 1/s).
+    # Multiply by s to get the PDF transform, which should be 1 at s->0.
+    s_small = np.array([1e-6])
+    val_0   = float(Psi_star_annulus(s_small, eps, tau0, tau1)[0] * s_small[0])
+    check("psi_pdf*(s->0) = 1  [Psi_star_annulus*s -> 1]",
+          close(val_0, 1.0, 1e-4),
+          f"Psi_star_annulus(1e-6)*s = {val_0:.8f}  (expected 1.0)")
+
+    # s -> large: PDF transform should go to 0
+    s_large = np.array([1e10])
+    val_inf = float(Psi_star_annulus(s_large, eps, tau0, tau1)[0] * s_large[0])
+    check("psi_pdf*(s->inf) -> 0  [Psi_star_annulus*s -> 0]",
+          val_inf < 1e-3,
+          f"Psi_star_annulus(1e10)*s = {val_inf:.2e}  (expected << 1)")
+
+    # Match reference PDF transform at 10 s values spanning both branches
+    # Psi_star_annulus*s vs _annulus_psi_ref (which returns the PDF transform)
+    s_test  = np.logspace(-4, 6, 10)
+    ref_psi = _annulus_psi_ref(s_test, eps, tau0, tau1)
+    mod_psi = Psi_star_annulus(s_test, eps, tau0, tau1) * s_test
+    max_err = float(np.max(np.abs(ref_psi - mod_psi)))
+    check("Psi_star_annulus*s matches reference PDF transform at 10 points",
+          max_err < 1e-8,
+          f"max abs diff = {max_err:.2e}")
+
+# ---------------------------------------------------------------------------
+# Test 2: Branch switch consistency
+# ---------------------------------------------------------------------------
+
+def test_branch_switch():
+    print("\nTest 2: Bessel branch switch at |s*tau1| = 100")
+    eps  = 1e-2
+    tau0 = 1e-4
+    tau1 = 1e3
+
+    # Evaluate just below and just above the threshold s*tau1 = 100
+    s_cross  = 100.0 / tau1  # = 0.1
+    s_below  = np.array([s_cross * 0.99])
+    s_above  = np.array([s_cross * 1.01])
+
+    # Both branches should give similar results at the crossover
+    # Use the reference which computes both and switches
+    psi_below_ref = float(_annulus_psi_ref(s_below, eps, tau0, tau1)[0])
+    psi_above_ref = float(_annulus_psi_ref(s_above, eps, tau0, tau1)[0])
+
+    # Values should be continuous across the switch
+    jump = abs(psi_below_ref - psi_above_ref)
+    check("psi*(s) is continuous across branch switch",
+          jump < 1e-4,
+          f"|psi*(0.99*s_cross) - psi*(1.01*s_cross)| = {jump:.2e}")
+
+    # Module should agree with reference on both sides
+    # Psi_star_annulus returns CDF transform (includes 1/s); multiply by s for PDF
+    psi_below_mod = float(Psi_star_annulus(s_below, eps, tau0, tau1)[0] * float(s_below[0]))
+    psi_above_mod = float(Psi_star_annulus(s_above, eps, tau0, tau1)[0] * float(s_above[0]))
+    err_below = abs(psi_below_mod - psi_below_ref)
+    err_above = abs(psi_above_mod - psi_above_ref)
+    check("Module matches reference below branch threshold",
+          err_below < 1e-8,
+          f"|mod - ref| = {err_below:.2e}  at s={float(s_below[0]):.4f}")
+    check("Module matches reference above branch threshold",
+          err_above < 1e-8,
+          f"|mod - ref| = {err_above:.2e}  at s={float(s_above[0]):.4f}")
+
+# ---------------------------------------------------------------------------
+# Test 3: Wronskian identity
+# ---------------------------------------------------------------------------
+
+def test_wronskian():
+    print("\nTest 3: Wronskian identity I0(x)*K1(x) + I1(x)*K0(x) = 1/x")
+    # This identity is a property of modified Bessel functions.
+    # If the denominator of psi* is computed correctly, it should satisfy
+    # this at q0 = q1 (i.e. r0 = r1, degenerate case).
+    for x in [0.1, 1.0, 5.0, 20.0]:
+        w = float(iv(0, x) * kv(1, x) + iv(1, x) * kv(0, x))
+        expected = 1.0 / x
+        err = abs(w - expected) / expected
+        check(f"Wronskian at x={x}: I0*K1 + I1*K0 = 1/x",
+              err < 1e-10,
+              f"computed = {w:.10f}, expected = {expected:.10f}")
+
+# ---------------------------------------------------------------------------
+# Test 4: Inverse CDF table
+# ---------------------------------------------------------------------------
+
+def test_inverse_cdf_table():
+    print("\nTest 4: _make_inverse_cdf_annulus()")
+    eps  = 1e-2
+    tau0 = 1e-4
+    tau1 = 1e3
+
+    try:
+        t_table, cdf_table = _make_inverse_cdf_annulus(
+            num_samples=100, eps=eps, tau0=tau0, tau1=tau1)
+    except Exception as e:
+        check("Table construction runs without error", False, str(e))
+        return
+
+    check("Table construction runs without error", True)
+    check("CDF starts at 0 (first entry <= 0.05)",
+          cdf_table[0] <= 0.05,
+          f"cdf_table[0] = {cdf_table[0]:.4f}")
+    check("CDF reaches 1 (last entry >= 0.99)",
+          cdf_table[-1] >= 0.99,
+          f"cdf_table[-1] = {cdf_table[-1]:.4f}")
+    check("CDF is monotone non-decreasing",
+          np.all(np.diff(cdf_table) >= 0),
+          f"min delta = {np.min(np.diff(cdf_table)):.2e}")
+    check("Table has no NaN or Inf",
+          np.all(np.isfinite(t_table)) and np.all(np.isfinite(cdf_table)))
+    check("Times are positive",
+          np.all(t_table > 0),
+          f"min t = {t_table.min():.2e}")
+
+# ---------------------------------------------------------------------------
+# Test 5: Monte Carlo vs analytical first-passage time CDF
+# ---------------------------------------------------------------------------
+
+def test_monte_carlo_vs_analytical():
+    print("\nTest 5: Monte Carlo vs analytical first-passage time CDF")
+
+    eps  = 1e-2
+    tau0 = 1e-4
+    tau1 = 1e3
+    N    = 100_000
+    seed = 42
+
+    # tau_D = tau1 for the annulus model
+    tau_D = tau1
+
+    print(f"         eps={eps}  tau0={tau0}  tau1={tau1}  N={N:,}")
+
+    # Build inverse CDF from the module
+    try:
+        t_table, cdf_table = _make_inverse_cdf_annulus(
+            num_samples=200, eps=eps, tau0=tau0, tau1=tau1)
+    except Exception as e:
+        check("MC table built", False, str(e))
+        return
+    check("MC table built", True)
+
+    # Sample return times (t_table is now dimensionless t/tau1; scale by tau_D=tau1)
+    np.random.seed(seed)
+    xi     = np.random.uniform(0, 1, N)
+    t_mc   = tau_D * np.interp(xi, cdf_table, t_table)  # physical times
+    check("All MC return times are positive",
+          np.all(t_mc > 0), f"min t_mc = {t_mc.min():.2e}")
+
+    # Analytical CDF: evaluate on physical time grid spanning [1e-10*tau1, 5*tau1]
+    V      = _ref_stehfest(16)
+    t_eval = np.logspace(np.log10(1e-10 * tau1), np.log10(5 * tau1), 300)
+    an_cdf = _stehfest_invert(_annulus_cdf_ref, t_eval, V,
+                               eps=eps, tau0=tau0, tau1=tau1)
+    an_cdf = np.clip(an_cdf, 0, 1)
+
+    # Direct comparison on a shared time grid well past t=0
+    # Use the range where the analytical CDF is between 0.05 and 0.95
+    an_cdf_clipped = np.clip(an_cdf, 0, 1)
+    mask   = (an_cdf_clipped > 0.02) & (an_cdf_clipped < 0.98)
+    if mask.sum() < 3:
+        check("MC vs analytical: enough points in (0.02, 0.98)", False,
+              f"only {mask.sum()} points"); return
+    t_check   = t_eval[mask][::max(1, mask.sum()//20)]  # ~20 evenly-spaced points
+    an_check  = an_cdf_clipped[mask][::max(1, mask.sum()//20)]
+    mc_check  = np.array([np.mean(t_mc <= t) for t in t_check])
+    max_dev   = float(np.max(np.abs(an_check - mc_check)))
+
+    check("MC CDF within 2% of analytical CDF on shared time grid",
+          max_dev < 0.02,
+          f"max |MC_CDF - analytical_CDF| = {max_dev:.4f}  (tol 0.02)")
+    print(f"         {len(t_check)} comparison points in t=[{t_check[0]:.2e}, {t_check[-1]:.2e}]")
+    print(f"         analytical CDF range: [{an_check[0]:.3f}, {an_check[-1]:.3f}]")
+    print(f"         MC CDF range:         [{mc_check[0]:.3f}, {mc_check[-1]:.3f}]")
+
+# ---------------------------------------------------------------------------
+# Test 6: Thin-shell limit (cylindrical -> slab as r1/r0 -> 1)
+# ---------------------------------------------------------------------------
+
+def test_thin_shell_limit():
+    print("\nTest 6: Thin-shell limit -- cylindrical CDF -> slab CDF")
+    # Set r0/r1 = 0.95 (5% relative gap, expect ~5% relative error)
+    # With tau0 = r0^2/D, tau1 = r1^2/D: tau0/tau1 = (r0/r1)^2 = 0.9025
+    r0_over_r1 = 0.95
+    eps_cyl    = 0.01   # small release position for cylinder
+    tau1       = 1.0    # reference
+    tau0       = r0_over_r1 ** 2 * tau1  # = 0.9025
+
+    # For slab: B = r1 - r0 = r1*(1 - r0/r1) = 1.0 * 0.05 = 0.05 (in units of r1)
+    # eps_slab = z'/B where z' = eps_cyl * r0 = 0.01 * 0.95 = 0.0095
+    B        = (1.0 - r0_over_r1) * np.sqrt(tau1)   # in physical units with D=1
+    eps_slab = eps_cyl * r0_over_r1 / (1.0 - r0_over_r1)  # = 0.01*0.95/0.05 = 0.19
+
+    V      = _ref_stehfest(16)
+    t_eval = np.logspace(-4, 1, 50)
+
+    cdf_cyl  = _stehfest_invert(_annulus_cdf_ref, t_eval, V,
+                                 eps=eps_cyl, tau0=tau0, tau1=tau1)
+    # slab CDF: tau_D = B^2/D_m; with D_m=1 and B in units of r1, tau_D = B^2
+    tau_D_slab = B ** 2
+    cdf_slab = _stehfest_invert(_slab_cdf_ref,
+                                 t_eval / tau_D_slab, V, eps=eps_slab)
+
+    cdf_cyl  = np.clip(cdf_cyl, 0, 1)
+    cdf_slab = np.clip(cdf_slab, 0, 1)
+
+    # Compare in the range where both CDFs are between 0.1 and 0.9
+    mask  = (cdf_slab > 0.1) & (cdf_slab < 0.9) & (cdf_cyl > 0.1) & (cdf_cyl < 0.9)
+    if mask.sum() == 0:
+        check("Thin-shell: overlapping CDF range found", False,
+              "no overlap in [0.1, 0.9]")
+        return
+    check("Thin-shell: overlapping CDF range found", True,
+          f"{mask.sum()} points in [0.1, 0.9]")
+    max_diff = float(np.max(np.abs(cdf_cyl[mask] - cdf_slab[mask])))
+    # At r0/r1=0.95 we expect ~5-10% difference (thin but not infinitely thin)
+    check("Thin-shell CDF difference < 15% (r0/r1=0.95)",
+          max_diff < 0.15,
+          f"max |CDF_cyl - CDF_slab| = {max_diff:.4f}  (tol 0.15)")
+
+# ---------------------------------------------------------------------------
+# Test 7: Mean return time sanity
+# ---------------------------------------------------------------------------
+
+def test_mean_return_time():
+    print("\nTest 7: Mean return time sanity check")
+    eps  = 1e-2
+    tau0 = 1e-4
+    tau1 = 1e3
+    N    = 50_000
+
+    t_table, cdf_table = _make_inverse_cdf_annulus(
+        num_samples=100, eps=eps, tau0=tau0, tau1=tau1)
+
+    np.random.seed(1)
+    xi    = np.random.uniform(0, 1, N)
+    t_mc  = tau1 * np.interp(xi, cdf_table, t_table)
+
+    mean_t = float(t_mc.mean())
+    check("Mean return time is positive and finite",
+          np.isfinite(mean_t) and mean_t > 0,
+          f"E[t_return] = {mean_t:.4e}")
+    # Return times should be << tau1 for small eps (particle starts near wall)
+    # and much less than 5*tau1
+    check("Mean return time < 5 * tau1",
+          mean_t < 5 * tau1,
+          f"E[t_return] = {mean_t:.4e}  tau1 = {tau1}")
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("  Cylindrical Annulus TDRW Verification")
+    print("  Against Analytical First-Passage Time CDF")
+    print("=" * 60)
+
+    test_psi_limits()
+    test_branch_switch()
+    test_wronskian()
+    test_inverse_cdf_table()
+    test_monte_carlo_vs_analytical()
+    test_thin_shell_limit()
+    test_mean_return_time()
+
+    n_pass = sum(p for _, p in RESULTS)
+    n_fail = len(RESULTS) - n_pass
+    print()
+    print("=" * 60)
+    print(f"  Results: {n_pass} passed, {n_fail} failed  "
+          f"({len(RESULTS)} total)")
+    print("=" * 60)
+    sys.exit(0 if n_fail == 0 else 1)

--- a/pydfnworks/tests/tdrw/verify_slab_tdrw.py
+++ b/pydfnworks/tests/tdrw/verify_slab_tdrw.py
@@ -35,7 +35,8 @@ from math import factorial
 # Import the module under test
 # ---------------------------------------------------------------------------
 
-from pydfnworks.dfnGraph.transport.tdrw.dentz import Psi_star, make_inverse_cdf
+from pydfnworks.dfnGraph.transport.tdrw.dentz import (
+    Psi_star, make_inverse_cdf, choose_release_eps)
 from pydfnworks.dfnGraph.transport.tdrw.stehfest import (
     stehfest_coefficients as _stehfest_coefficients, )
 
@@ -321,6 +322,67 @@ def test_mean_matrix_time():
           f"E[t_matrix] = {mean_md:.4e}  (expected 1e-5 to 10)")
 
 # ---------------------------------------------------------------------------
+# Test 7: Field-scale parameters with adaptive release position
+# ---------------------------------------------------------------------------
+
+def test_field_scale_adaptive_eps():
+    """ Large matrix blocks at field-scale diffusivity: the fixed release
+    position eps=1e-4 fails here (its artifact scale (eps*B)^2/D lands in
+    the observation window and most particles get zero trapping events).
+    choose_release_eps must shrink eps enough to reproduce Sudicky-Frind.
+    Reference CDF via mpmath Talbot inversion: Stehfest smears the sharp
+    BTC front and cannot be used as the reference at these times. """
+    print("\nTest 7: Field-scale parameters + adaptive release position")
+    import mpmath as mp
+
+    phi_m, D_m, b_f = 0.01, 1e-14, 2e-5
+    spacing = 276.0
+    B = spacing / 2
+    tau_adv = 1e8
+    tau_D = B ** 2 / D_m
+    N = 100_000
+
+    eps = choose_release_eps(tau_adv, B, D_m)
+    check("Adaptive eps engages (eps < 1e-4)", eps < 1e-4,
+          f"eps = {eps:.3e}")
+    artifact = (eps * B) ** 2 / D_m
+    check("Artifact timescale << tau_adv", artifact < 0.01 * tau_adv,
+          f"(eps*B)^2/D = {artifact:.2e} s, tau_adv = {tau_adv:.2e} s")
+
+    t_table, cdf_table = _make_inverse_cdf_spline_for_times(eps=eps)
+    gamma = phi_m * D_m / (b_f * eps * B)
+    n_avg = gamma * tau_adv
+    check("Mean trapping events >= 1", n_avg >= 1.0,
+          f"n_avg = {n_avg:.2f}")
+
+    np.random.seed(7)
+    n_all = np.random.poisson(n_avg, N)
+    xi = np.random.uniform(0, 1, int(n_all.sum()))
+    t_trap = tau_D * np.interp(xi, cdf_table, t_table)
+    pid = np.repeat(np.arange(N), n_all)
+    t_mc = tau_adv + np.bincount(pid, weights=t_trap, minlength=N)
+
+    def SF_talbot(t):
+        F = lambda s: mp.e ** (-tau_adv * (s + (phi_m / b_f)
+                                           * mp.sqrt(s * D_m)
+                                           * mp.tanh(B * mp.sqrt(s / D_m)))) / s
+        return float(mp.invertlaplace(F, t, method='talbot'))
+
+    t_check = np.logspace(np.log10(1.1 * tau_adv),
+                          np.log10(3000 * tau_adv), 15)
+    sf = np.clip([SF_talbot(t) for t in t_check], 0, 1)
+    t_s = np.sort(t_mc)
+    mc = np.interp(t_check, t_s, np.arange(1, N + 1) / N)
+    mask = (sf > 0.01) & (sf < 0.995)
+    max_dev = float(np.max(np.abs(mc - sf)[mask]))
+    check("MC CDF within 3% of Sudicky-Frind (Talbot) at field scale",
+          max_dev < 0.03,
+          f"max |MC_CDF - SF_CDF| = {max_dev:.4f}  (tolerance 0.03)")
+    print(f"         eps={eps:.2e}  n_avg={n_avg:.1f}  "
+          f"artifact={artifact:.2e} s")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -336,6 +398,7 @@ if __name__ == "__main__":
     test_gamma_formula()
     test_monte_carlo_vs_sudicky_frind()
     test_mean_matrix_time()
+    test_field_scale_adaptive_eps()
 
     n_pass = sum(p for _, p in RESULTS)
     n_fail = len(RESULTS) - n_pass

--- a/pydfnworks/tests/tdrw/verify_slab_tdrw.py
+++ b/pydfnworks/tests/tdrw/verify_slab_tdrw.py
@@ -1,0 +1,347 @@
+"""
+verify_slab_tdrw.py
+-------------------
+Verification script for tdrw_finite_dentz.py (slab matrix diffusion TDRW).
+
+Designed for Claude Code: imports the dfnWorks module under test and compares
+it against the Sudicky and Frind (1982) analytical solution.
+
+Tests
+-----
+  1. Stehfest coefficients sum to zero (pure math check)
+  2. Slab psi*(s) Laplace limiting behavior: psi*(0)=1, psi*(inf)=0
+  3. Inverse CDF table from _make_inverse_cdf_spline_for_times:
+       monotone, starts at 0, ends at 1
+  4. Trapping rate formula gamma with known parameters
+  5. Monte Carlo BTC vs Sudicky-Frind analytical CDF at 10 quantiles
+  6. Mean matrix diffusion time consistency
+
+Run with:
+    python verify_slab_tdrw.py
+
+All tests print PASS / FAIL with numerical details.
+A final summary line exits with code 0 (all pass) or 1 (any fail).
+
+Reference
+---------
+Sudicky, E.A., Frind, E.O., 1982. Water Resour. Res. 18(6), 1634-1642.
+"""
+
+import sys
+import numpy as np
+from math import factorial
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+from pydfnworks.dfnGraph.transport.tdrw.dentz import Psi_star, make_inverse_cdf
+from pydfnworks.dfnGraph.transport.tdrw.stehfest import (
+    stehfest_coefficients as _stehfest_coefficients, )
+
+# same signature as the pre-2.12 flat-layout builder
+_make_inverse_cdf_spline_for_times = make_inverse_cdf
+print("Testing pydfnworks.dfnGraph.transport.tdrw.dentz")
+
+# ---------------------------------------------------------------------------
+# Standalone Stehfest and analytical helpers (independent of the module)
+# ---------------------------------------------------------------------------
+
+def _ref_stehfest(N=16):
+    """Reference Stehfest coefficients -- independent implementation."""
+    M = N // 2
+    V = np.zeros(N)
+    for i in range(1, N + 1):
+        total = 0.0
+        for k in range(int((i + 1) // 2), min(i, M) + 1):
+            num = (k ** M) * factorial(2 * k)
+            den = (factorial(M - k) * factorial(k) * factorial(k - 1)
+                   * factorial(i - k) * factorial(2 * k - i))
+            total += num / den
+        V[i - 1] = ((-1) ** (i + M)) * total
+    return V
+
+
+def _stehfest_invert(F, t_arr, V, **kw):
+    ln2 = np.log(2.0)
+    f   = np.zeros(len(t_arr))
+    for idx, t in enumerate(t_arr):
+        sv  = np.array([(i + 1) * ln2 / t for i in range(len(V))])
+        f[idx] = (ln2 / t) * np.dot(V, F(sv, **kw))
+    return f
+
+
+def _SF_cdf_laplace(s, tau_adv, phi_m, b_f, D_m, B):
+    """Sudicky-Frind (1982) CDF Laplace transform (reference solution)."""
+    q           = np.sqrt(s / D_m)
+    matrix_term = (phi_m / b_f) * np.sqrt(s * D_m) * np.tanh(B * q)
+    return np.exp(-tau_adv * (s + matrix_term)) / s
+
+
+def _slab_psi_laplace(s, eps):
+    """Slab psi_eps*(s), scaled form -- reference implementation."""
+    q = np.sqrt(s)
+    return (np.exp(-eps * q) * (1.0 + np.exp(-2.0 * (1.0 - eps) * q))
+            / (1.0 + np.exp(-2.0 * q)))
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+RESULTS = []
+
+def check(name, passed, detail=""):
+    status = "PASS" if passed else "FAIL"
+    msg    = f"  [{status}] {name}"
+    if detail:
+        msg += f"\n         {detail}"
+    print(msg)
+    RESULTS.append((name, passed))
+
+
+def close(a, b, tol):
+    return abs(a - b) / max(abs(b), 1e-30) < tol
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Stehfest coefficients
+# ---------------------------------------------------------------------------
+
+def test_stehfest_coefficients():
+    print("\nTest 1: Stehfest coefficients")
+    V_ref = _ref_stehfest(N=16)
+    try:
+        V_mod = _stehfest_coefficients(N=16)
+        match = np.allclose(V_ref, V_mod, rtol=1e-10)
+        check("Coefficients match reference", match,
+              f"max diff = {np.max(np.abs(V_ref - V_mod)):.2e}")
+    except Exception as e:
+        check("Coefficients match reference", False, str(e))
+    # Stehfest property: sum of V_i * i^k is related to k-th derivative at t=1
+    # Simple check: invert F(s)=1/s (identity) -- should give f(t)=1
+    V = _ref_stehfest(16)
+    # For F(s)=1/s, Stehfest gives f(t) = sum_i V_i/i (should = 1)
+    f_at_1 = float(np.sum(V / np.arange(1, len(V)+1)))
+    check("Stehfest: sum(V_i/i) = 1 (inverts F(s)=1/s)",
+          close(f_at_1, 1.0, 1e-6), f"sum(V_i/i) = {f_at_1:.10f}")
+
+# ---------------------------------------------------------------------------
+# Test 2: Laplace-domain limiting behavior of psi_eps
+# ---------------------------------------------------------------------------
+
+def test_psi_limits():
+    print("\nTest 2: psi_eps*(s) limiting behavior")
+    eps = 1e-4
+    # Note: Psi_star(s, eps) = CDF transform = psi_eps*(s) / s
+    # Multiply by s to recover the PDF transform, which should be 1 at s=0
+    s_small = np.array([1e-6])
+    val_0   = float(Psi_star(s_small, eps)[0] * s_small[0])
+    check("psi_pdf*(s->0) = 1  [Psi_star(s)*s -> 1]",
+          close(val_0, 1.0, 1e-6),
+          f"Psi_star(1e-6)*s = {val_0:.8f}  (expected 1.0)")
+    # CDF transform Psi_star(s)*s -> 0 for s >> 1/eps^2
+    # For eps=1e-4: need s >> 1e8; use 1e12 to be well past threshold
+    s_large = np.array([1e12])
+    val_inf = float(Psi_star(s_large, eps)[0] * s_large[0])
+    check("psi_pdf*(s->inf) -> 0  [Psi_star(s)*s -> 0 for s>>1/eps^2]",
+          val_inf < 1e-3,
+          f"Psi_star(1e12)*s = {val_inf:.2e}  (expected << 1)")
+    # Verify PDF transform against reference scaled form
+    s_test  = np.logspace(-2, 4, 8)
+    ref     = _slab_psi_laplace(s_test, eps)           # PDF transform
+    mod     = Psi_star(s_test, eps) * s_test           # module CDF * s = PDF
+    max_err = float(np.max(np.abs(ref - mod)))
+    check("Psi_star(s)*s matches reference PDF transform (8 points)",
+          max_err < 1e-10,
+          f"max abs diff = {max_err:.2e}")
+
+# ---------------------------------------------------------------------------
+# Test 3: inverse CDF table from the module
+# ---------------------------------------------------------------------------
+
+def test_inverse_cdf_table():
+    print("\nTest 3: _make_inverse_cdf_spline_for_times()")
+    eps = 1e-4
+    try:
+        t_table, cdf_table = _make_inverse_cdf_spline_for_times(
+            num_samples=100, eps=eps)
+    except Exception as e:
+        check("Table construction runs without error", False, str(e))
+        return
+
+    check("Table construction runs without error", True)
+    check("CDF starts at 0 (first entry <= 0.05)",
+          cdf_table[0] <= 0.05,
+          f"cdf_table[0] = {cdf_table[0]:.4f}")
+    check("CDF reaches 1 (last entry >= 0.99)",
+          cdf_table[-1] >= 0.99,
+          f"cdf_table[-1] = {cdf_table[-1]:.4f}")
+    check("CDF is monotone non-decreasing",
+          np.all(np.diff(cdf_table) >= 0),
+          f"min delta = {np.min(np.diff(cdf_table)):.2e}")
+    check("Table has no NaN or Inf",
+          np.all(np.isfinite(t_table)) and np.all(np.isfinite(cdf_table)))
+    check("Times are positive",
+          np.all(t_table > 0),
+          f"min t = {t_table.min():.2e}")
+
+# ---------------------------------------------------------------------------
+# Test 4: gamma formula
+# ---------------------------------------------------------------------------
+
+def test_gamma_formula():
+    print("\nTest 4: Trapping rate gamma formula")
+    # gamma = phi_m * D_m / (b_f * eps * B)
+    # Test known values
+    cases = [
+        dict(phi_m=0.05, D_m=1e-10, b_f=1e-4, eps=1e-4, B=0.05,
+             gamma_expected=0.05*1e-10/(1e-4*1e-4*0.05)),
+        dict(phi_m=0.01, D_m=1e-11, b_f=5e-5, eps=1e-4, B=0.1,
+             gamma_expected=0.01*1e-11/(5e-5*1e-4*0.1)),
+    ]
+    for c in cases:
+        gamma = c['phi_m'] * c['D_m'] / (c['b_f'] * c['eps'] * c['B'])
+        check(f"gamma={c['gamma_expected']:.2e} for phi_m={c['phi_m']}",
+              close(gamma, c['gamma_expected'], 1e-10),
+              f"computed = {gamma:.6e}, expected = {c['gamma_expected']:.6e}")
+
+# ---------------------------------------------------------------------------
+# Test 5: Monte Carlo BTC vs Sudicky-Frind analytical CDF
+# ---------------------------------------------------------------------------
+
+def test_monte_carlo_vs_sudicky_frind():
+    print("\nTest 5: Monte Carlo BTC vs Sudicky-Frind (1982)")
+
+    # Physical parameters: eps=0.01 gives gamma=10, n_avg=10, tau_D/tau_adv=10
+    # Using eps=0.01 (not module default 1e-4) to keep n_avg tractable.
+    # The mathematical equivalence holds for any eps; the approximation
+    # error is O(eps^2) = 1e-4 here, well within the 2% test tolerance.
+    tau_adv = 1.0
+    D_m     = 0.1
+    B       = 1.0
+    phi_m   = 0.05
+    b_f     = 0.05
+    eps     = 0.01    # use 0.01 so gamma=10, not 0.0001 which gives gamma=1000
+
+    tau_D   = B ** 2 / D_m                    # = 10
+    gamma   = phi_m * D_m / (b_f * eps * B)   # = 10
+    n_avg   = gamma * tau_adv                  # = 10
+    N       = 100_000
+    seed    = 42
+
+    print(f"         tau_adv={tau_adv}  tau_D={tau_D:.1f}  "
+          f"gamma={gamma:.1f}  n_avg={n_avg:.1f}  N={N:,}")
+
+    # Build inverse CDF table
+    try:
+        t_table, cdf_table = _make_inverse_cdf_spline_for_times(
+            num_samples=200, eps=eps)
+    except Exception as e:
+        check("Monte Carlo table built", False, str(e))
+        return
+    check("Monte Carlo table built", True)
+
+    # Sample
+    np.random.seed(seed)
+    n_all      = np.random.poisson(n_avg, N)
+    n_total    = int(n_all.sum())
+    xi_all     = np.random.uniform(0, 1, n_total)
+    t_trap_all = tau_D * np.interp(xi_all, cdf_table, t_table)
+    pid        = np.repeat(np.arange(N), n_all)
+    t_matrix   = np.bincount(pid, weights=t_trap_all, minlength=N)
+    t_mc       = tau_adv + t_matrix
+
+    check("All MC travel times >= tau_adv",
+          np.all(t_mc >= tau_adv - 1e-12),
+          f"min t_mc = {t_mc.min():.6f}  tau_adv = {tau_adv}")
+
+    # Analytical Sudicky-Frind CDF via Stehfest
+    V      = _ref_stehfest(16)
+    t_eval = np.logspace(np.log10(tau_adv * 0.95),
+                         np.log10(tau_adv + 5 * tau_D), 200)
+    sf_cdf = _stehfest_invert(_SF_cdf_laplace, t_eval, V,
+                               tau_adv=tau_adv, phi_m=phi_m, b_f=b_f,
+                               D_m=D_m, B=B)
+    sf_cdf = np.clip(sf_cdf, 0, 1)
+
+    # Compare CDFs directly on a shared time grid (t > tau_adv only)
+    t_check   = np.logspace(np.log10(1.5 * tau_adv),
+                             np.log10(tau_adv + 5 * tau_D), 20)
+    sf_check  = _stehfest_invert(_SF_cdf_laplace, t_check, V,
+                                  tau_adv=tau_adv, phi_m=phi_m, b_f=b_f,
+                                  D_m=D_m, B=B)
+    sf_check  = np.clip(sf_check, 0, 1)
+    mc_check  = np.array([np.mean(t_mc <= t) for t in t_check])
+    max_dev   = float(np.max(np.abs(sf_check - mc_check)))
+
+    # Tolerance 3%: accounts for O(eps^2)=1e-4 approx error plus
+    # ~1-2% Stehfest inaccuracy near the advective front at t=1.5*tau_adv
+    check("MC CDF within 3% of Sudicky-Frind on 20-point time grid",
+          max_dev < 0.03,
+          f"max |MC_CDF - SF_CDF| = {max_dev:.4f}  (tolerance 0.03)")
+    print(f"         t range: [{t_check[0]:.3f}, {t_check[-1]:.1f}]")
+    print(f"         SF CDF range: [{sf_check[0]:.3f}, {sf_check[-1]:.3f}]")
+    print(f"         MC CDF range: [{mc_check[0]:.3f}, {mc_check[-1]:.3f}]")
+
+# ---------------------------------------------------------------------------
+# Test 6: Mean matrix diffusion time
+# ---------------------------------------------------------------------------
+
+def test_mean_matrix_time():
+    print("\nTest 6: Mean matrix diffusion time")
+    # For the slab, E[tau | n=1] = tau_D * E[psi_eps]
+    # E[psi_eps] ~ eps * B / 3 for small eps (first moment of slab FPT)
+    # But this is harder to compute analytically; instead verify that
+    # E[t_matrix] = gamma * tau_adv * tau_D * E[psi_eps]
+    # We check it's positive and finite.
+    eps    = 1e-4
+    tau_D  = 10.0
+    gamma  = 10.0
+    tau_adv = 1.0
+    N      = 50_000
+
+    t_table, cdf_table = _make_inverse_cdf_spline_for_times(
+        num_samples=100, eps=eps)
+
+    np.random.seed(0)
+    n_all   = np.random.poisson(gamma * tau_adv, N)
+    xi      = np.random.uniform(0, 1, int(n_all.sum()))
+    t_trap  = tau_D * np.interp(xi, cdf_table, t_table)
+    pid     = np.repeat(np.arange(N), n_all)
+    t_mat   = np.bincount(pid, weights=t_trap, minlength=N)
+
+    mean_md = float(t_mat.mean())
+    check("Mean matrix diffusion time is positive and finite",
+          np.isfinite(mean_md) and mean_md > 0,
+          f"E[t_matrix] = {mean_md:.4f}")
+    # Rough sanity: should be O(gamma * tau_adv * tau_D * eps)
+    # For eps=1e-4, this is ~ 10 * 1 * 10 * 1e-4 ~ 0.01
+    check("Mean matrix diffusion time is in plausible range",
+          1e-5 < mean_md < 10.0,
+          f"E[t_matrix] = {mean_md:.4e}  (expected 1e-5 to 10)")
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("  Slab (Dentz) TDRW Verification")
+    print("  Against Sudicky and Frind (1982)")
+    print("=" * 60)
+
+    test_stehfest_coefficients()
+    test_psi_limits()
+    test_inverse_cdf_table()
+    test_gamma_formula()
+    test_monte_carlo_vs_sudicky_frind()
+    test_mean_matrix_time()
+
+    n_pass = sum(p for _, p in RESULTS)
+    n_fail = len(RESULTS) - n_pass
+    print()
+    print("=" * 60)
+    print(f"  Results: {n_pass} passed, {n_fail} failed  "
+          f"({len(RESULTS)} total)")
+    print("=" * 60)
+    sys.exit(0 if n_fail == 0 else 1)


### PR DESCRIPTION
## Summary

Ports the finite matrix-diffusion TDRW algorithms from `bug_fix/graph_transport_finite_tdrw` onto the subpackage layout introduced in #149, replacing `transport/tdrw.py` with a `transport/tdrw/` subpackage:

- **`setup.py`** — parameter validation (per-model requirements) and the per-model inverse-CDF setup dispatch
- **`stehfest.py`** — shared Gaver-Stehfest inversion + inverse-CDF table builder (deduplicated)
- **`trapping.py`** — shared Poisson trapping-event sampler (dentz / annulus / from_file)
- **`infinite.py`**, **`roubinet.py`** — existing models, unchanged physics
- **`dentz.py`** — finite slab first-passage model (Stehfest-inverted CDF)
- **`annulus.py`** — finite cylindrical annulus model (absorbing inner / reflecting outer wall)
- **`from_file.py`** — return-time CDF read from a two-column file

`run_graph_transport` gains `tdrw_model` and `tdrw_filename`. The per-particle `SeedSequence` seeding from #153 is kept; percentage-based progress logging added.

## Physics fixes found during verification

1. **Inverse-CDF table construction**: sorting Stehfest output by CDF value scrambles (time, cdf) pairs wherever ringing exceeds adjacent CDF spacing — sampled mean return time biased **+59%** at the default table size, non-convergent under refinement. Replaced with a running maximum along the time axis (+1.2%, converging).
2. **`fracture_spacing` convention standardized** as the full spacing between adjacent fractures (legacy roubinet meaning); dentz/annulus/from_file now use half-width B = spacing/2 in the trapping rate and tau_D.
3. **Annulus table** was hard-wired to dimensionless tau0=1e-4, tau1=1e3 with an incorrect x1000 rescale — return times came out 1000x too long. Now tau1-normalized with the geometry ratio (r0/r1)^2 computed per network (geometric-mean aperture / 2 over spacing / 2), adaptive time range.
4. **Adaptive release position for the dentz model**: the fixed eps=1e-4 fails at field scale — the artifact scale (eps·B)^2/D lands inside the observation window and the mean trapping-event count drops below 1, so breakthrough curves hug the advective peak and larger spacings counterintuitively look *farther* from the infinite-matrix limit (max CDF error 0.85 vs Sudicky-Frind at spacing 276 m, D=1e-14). eps is now chosen per network as sqrt(1e-3 · D · t_char)/B (t_char = fastest advective source-to-target path), capped at 1e-4 and floored at 1e-8 with a warning, threaded through `Particle.release_eps` so the trapping rate always matches the table; the table time range scales with eps. Field-scale error after the fix: 0.014 at the immediate front, <0.002 elsewhere (~16 events/particle).
5. Fixed missing dispatch of the `from_file` model in `Particle.track()` (validated but silently skipped on the source branch), and a missing `local_print_log` import in `attributes/perm_area.py`.

## New defaults

- `run_graph_flow`: `conductance_model='doolaeghe'` (was `'karra'`)
- `run_graph_transport`: `fracture_spacing` without a `tdrw_model` selects `'dentz'` (warning names `'roubinet'` for pre-2.12 behavior)
- Version bumped to **2.12**

## Verification

Suites committed under `pydfnworks/tests/tdrw/` (run `python run_tdrw_verification.py`; exit 0 = pass, all 47 checks pass on this branch):

- **Dentz slab**: 100k-particle MC BTC within 0.6% of the Sudicky-Frind (1982) analytical solution (mpmath Talbot inversion; note Stehfest smears the sharp BTC front by up to +3.7% CDF and is not used for reference curves), plus a **field-scale case** (spacing 276 m, D=1e-14) exercising the adaptive eps: within 1.5%
- **Annulus**: sampled return-time quantiles within 0.3% of the analytical first-passage CDF at arbitrary geometry; thin-shell limit converges to the slab solution
- **Roubinet**: within 2.8% of Sudicky-Frind (inherent to its segment approximation; code path unchanged from master)
- **Regression**: with explicit `conductance_model='karra'` and `tdrw_model='roubinet'`, infinite and roubinet results are identical to master (fixed seed, graph_transport example network); serial and parallel runs agree and are deterministic

## Example

`examples/finite_matrix_diffusion/` demonstrates the method on a Forsmark-like network: a spacing sweep (cutoffs marching with tau_D = (spacing/2)^2/D, largest overlaying the infinite reference), a diffusivity sweep at fixed spacing, and site-tied spacings (1/P32 and 1/dQ), with a run-matrix CSV of predicted feature timescales and a plotting script.

Supersedes `bug_fix/graph_transport_finite_tdrw` (that branch can be deleted after merge).

